### PR TITLE
Add grouping rule for the Alchemist simulator

### DIFF
--- a/dependencies/src/main/resources/refreshVersions-rules/other-version-alias-rules.txt
+++ b/dependencies/src/main/resources/refreshVersions-rules/other-version-alias-rules.txt
@@ -6,3 +6,6 @@ com.squareup.*:*
 
 io.ktor:*
    ^^^^
+
+it.unibo.alchemist:alchemist-*
+         ^^^^^^^^^


### PR DESCRIPTION
## Issue

The [Alchemist Simulator](https://alchemistsimulator.github.io/) is usually used via Gradle and refreshVersions is in use in the reference projects.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ X ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR allows for using a single version identifier for all the components of the simulator, which must get pulled at once.
