### PR TITLE
Allow pointing to a custom versions properties file

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCorePlugin.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCorePlugin.kt
@@ -3,6 +3,7 @@ package de.fayard.refreshVersions.core
 import de.fayard.refreshVersions.core.extensions.isBuildSrc
 import de.fayard.refreshVersions.core.extensions.isRootProject
 import de.fayard.refreshVersions.core.extensions.registerOrCreate
+import de.fayard.refreshVersions.core.internal.RefreshVersionsInternals
 import de.fayard.refreshVersions.core.internal.writeUsedDependencies
 import de.fayard.refreshVersions.core.internal.writeUsedRepositories
 import org.gradle.api.Plugin
@@ -14,7 +15,8 @@ open class RefreshVersionsCorePlugin : Plugin<Project> {
         check(project.isRootProject) { "ERROR: de.fayard.refreshVersions.core should not be applied manually" }
         project.tasks.registerOrCreate<RefreshVersionsTask>(name = "refreshVersions") {
             group = "Help"
-            description = "Search for new dependencies versions and update versions.properties"
+            val versionsFileName = RefreshVersionsInternals.versionsPropertiesFile.name
+            description = "Search for new dependencies versions and update $versionsFileName"
         }
         if (project.isBuildSrc) project.afterEvaluate {
             writeUsedDependencies()

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -13,7 +13,7 @@ import org.gradle.kotlin.dsl.apply
 import java.io.File
 
 /**
- * Boostrap refreshVersions **only** (without the dependencies plugin).
+ * Boostrap refreshVersions-core **only** (excludes dependencies constants and version key rules).
  *
  * Supports both Kotlin and Groovy Gradle DSL.
  *
@@ -22,7 +22,7 @@ import java.io.File
  * import de.fayard.refreshVersions.core.bootstrap
  *
  * buildscript {
- *     dependencies.classpath("de.fayard.refreshVersions:refreshVersions:VERSION")
+ *     dependencies.classpath("de.fayard.refreshVersions:refreshVersions-core:VERSION")
  * }
  *
  * settings.bootstrapRefreshVersionsCore()
@@ -32,7 +32,7 @@ import java.io.File
  * ```groovy
  * import de.fayard.refreshVersions.core.RefreshVersionsCoreSetup
  * buildscript {
- *     dependencies.classpath("de.fayard.refreshVersions:refreshVersions:VERSION")
+ *     dependencies.classpath("de.fayard.refreshVersions:refreshVersions-core:VERSION")
  * }
  *
  * RefreshVersionsCoreSetup.bootstrap(settings)

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/InternalExtensions.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/InternalExtensions.kt
@@ -1,14 +1,12 @@
 package de.fayard.refreshVersions.core.internal
 
-import de.fayard.refreshVersions.core.artifactVersionKeyReader
+import de.fayard.refreshVersions.core.extensions.isBuildSrc
 import de.fayard.refreshVersions.core.extensions.isGradlePlugin
 import de.fayard.refreshVersions.core.extensions.moduleIdentifier
-import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.initialization.Settings
-import org.gradle.api.invocation.Gradle
-import java.util.Properties
+import java.io.File
 
 @InternalRefreshVersionsApi
 fun Dependency.hasHardcodedVersion(
@@ -35,21 +33,7 @@ fun Dependency.isManageableVersion(
 }
 
 @InternalRefreshVersionsApi
-fun @Suppress("unused") Gradle.retrieveVersionKeyReader(): ArtifactVersionKeyReader {
-    return artifactVersionKeyReader
-}
-
-@InternalRefreshVersionsApi
-fun Project.getVersionProperties(): Map<String, String> = mutableMapOf<String, String>().also { map ->
-    // Read from versions.properties
-    Properties().also { properties ->
-        properties.load(versionsPropertiesFile().reader())
-    }.forEach { (k, v) -> if (k is String && v is String) map[k] = v }
-}
-
-internal fun Settings.getVersionProperties(): Map<String, String> = mutableMapOf<String, String>().also { map ->
-    // Read from versions.properties
-    Properties().also { properties ->
-        properties.load(versionsPropertiesFile().reader())
-    }.forEach { (k, v) -> if (k is String && v is String) map[k] = v }
+fun Settings.defaultVersionsPropertiesFile(): File {
+    val relativePath = "versions.properties".let { if (settings.isBuildSrc) "../$it" else it }
+    return settings.rootDir.resolve(relativePath)
 }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/RefreshVersionsInternals.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/RefreshVersionsInternals.kt
@@ -1,0 +1,29 @@
+package de.fayard.refreshVersions.core.internal
+
+import java.io.File
+import java.util.Properties
+
+@InternalRefreshVersionsApi
+object RefreshVersionsInternals {
+
+    val versionKeyReader: ArtifactVersionKeyReader
+        get() = privateArtifactVersionKeyReader
+
+    val versionsPropertiesFile: File
+        get() = privateVersionsPropertiesFile
+
+    @Suppress("unchecked_cast")
+    fun readVersionProperties(): Map<String, String> = Properties().apply {
+        load(versionsPropertiesFile.reader())
+    } as Map<String, String>
+
+    internal fun initialize(artifactVersionKeyRules: List<String>, versionsPropertiesFile: File) {
+        privateVersionsPropertiesFile = versionsPropertiesFile.also {
+            it.createNewFile() // Creates the file if it doesn't exist yet
+        }
+        privateArtifactVersionKeyReader = ArtifactVersionKeyReader.fromRules(filesContent = artifactVersionKeyRules)
+    }
+
+    private lateinit var privateArtifactVersionKeyReader: ArtifactVersionKeyReader
+    private lateinit var privateVersionsPropertiesFile: File
+}

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPropertiesWriting.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPropertiesWriting.kt
@@ -13,11 +13,9 @@ internal data class DependencyWithVersionCandidates(
 internal fun Project.updateVersionsProperties(
     dependenciesWithLastVersion: List<DependencyWithVersionCandidates>
 ) {
-    val file = file("versions.properties")
-    if (file.exists().not()) file.createNewFile()
 
-    val properties: Map<String, String> = getVersionProperties()
-    val versionKeyReader = gradle.retrieveVersionKeyReader()
+    val properties: Map<String, String> = RefreshVersionsInternals.readVersionProperties()
+    val versionKeyReader = RefreshVersionsInternals.versionKeyReader
 
     val newFileContent = buildString {
         appendln(fileHeader)
@@ -47,7 +45,7 @@ internal fun Project.updateVersionsProperties(
             .sortedBy { it.key }
             .forEach { appendVersionWithUpdatesIfAvailable(it) }
     }
-    file.writeText(newFileContent)
+    RefreshVersionsInternals.versionsPropertiesFile.writeText(newFileContent)
 }
 
 internal fun writeWithAddedVersions(

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
@@ -8,6 +8,32 @@ import org.gradle.api.initialization.Settings
 import org.gradle.kotlin.dsl.apply
 import java.io.File
 
+/**
+ * Boostrap refreshVersions.
+ *
+ * Supports both Kotlin and Groovy Gradle DSL.
+ *
+ * // **`settings.gradle.kts`**
+ * ```kotlin
+ * import de.fayard.refreshVersions.bootstrapRefreshVersions
+ *
+ * buildscript {
+ *     dependencies.classpath("de.fayard.refreshVersions:refreshVersions:VERSION")
+ * }
+ *
+ * settings.bootstrapRefreshVersions()
+ * ```
+ *
+ * // **`settings.gradle`**
+ * ```groovy
+ * import de.fayard.refreshVersions.RefreshVersionsSetup
+ * buildscript {
+ *     dependencies.classpath("de.fayard.refreshVersions:refreshVersions:VERSION")
+ * }
+ *
+ * RefreshVersionsSetup.bootstrap(settings)
+ * ```
+ */
 @JvmOverloads
 @JvmName("bootstrap")
 fun Settings.bootstrapRefreshVersions(
@@ -16,7 +42,7 @@ fun Settings.bootstrapRefreshVersions(
 ) {
     bootstrapRefreshVersionsCore(
         artifactVersionKeyRules = if (extraArtifactVersionKeyRules.isEmpty()) {
-            RefreshVersionsPlugin.artifactVersionKeyRules //Avoid unneeded list copy.
+            RefreshVersionsPlugin.artifactVersionKeyRules // Avoid unneeded list copy.
         } else {
             RefreshVersionsPlugin.artifactVersionKeyRules + extraArtifactVersionKeyRules
         },

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
@@ -9,6 +9,7 @@ import org.gradle.kotlin.dsl.apply
 import java.io.File
 
 @JvmOverloads
+@JvmName("bootstrap")
 fun Settings.bootstrapRefreshVersions(
     extraArtifactVersionKeyRules: List<String> = emptyList(),
     versionsPropertiesFile: File = defaultVersionsPropertiesFile()

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
@@ -3,19 +3,23 @@
 package de.fayard.refreshVersions
 
 import de.fayard.refreshVersions.core.bootstrapRefreshVersionsCore
+import de.fayard.refreshVersions.core.internal.defaultVersionsPropertiesFile
 import org.gradle.api.initialization.Settings
 import org.gradle.kotlin.dsl.apply
+import java.io.File
 
 @JvmOverloads
 fun Settings.bootstrapRefreshVersions(
-    extraArtifactVersionKeyRules: List<String> = emptyList()
+    extraArtifactVersionKeyRules: List<String> = emptyList(),
+    versionsPropertiesFile: File = defaultVersionsPropertiesFile()
 ) {
     bootstrapRefreshVersionsCore(
         artifactVersionKeyRules = if (extraArtifactVersionKeyRules.isEmpty()) {
             RefreshVersionsPlugin.artifactVersionKeyRules //Avoid unneeded list copy.
         } else {
             RefreshVersionsPlugin.artifactVersionKeyRules + extraArtifactVersionKeyRules
-        }
+        },
+        versionsPropertiesFile = versionsPropertiesFile
     )
     gradle.rootProject {
         apply<RefreshVersionsPlugin>()

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/internal/ConfigurationDependenciesMigration.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/internal/ConfigurationDependenciesMigration.kt
@@ -1,11 +1,8 @@
 package de.fayard.refreshVersions.internal
 
+import de.fayard.refreshVersions.core.internal.*
 import de.fayard.refreshVersions.core.internal.cli.AnsiColor
 import de.fayard.refreshVersions.core.internal.cli.CliGenericUi
-import de.fayard.refreshVersions.core.internal.getVersionPropertyName
-import de.fayard.refreshVersions.core.internal.hasHardcodedVersion
-import de.fayard.refreshVersions.core.internal.retrieveVersionKeyReader
-import de.fayard.refreshVersions.core.internal.writeCurrentVersionInProperties
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ExternalDependency
@@ -34,7 +31,7 @@ private fun Project.attemptDependencyMigration(
     versionsProperties: Map<String, String>,
     dependency: ExternalDependency
 ) {
-    val versionKeyReader = gradle.retrieveVersionKeyReader()
+    val versionKeyReader = RefreshVersionsInternals.versionKeyReader
 
     if (dependency.hasHardcodedVersion(versionsProperties, versionKeyReader).not()) return
     val currentVersion = dependency.version ?: return
@@ -97,7 +94,8 @@ private fun offerReplacingHardcodedVersionWithConstantOrPlaceholder(
 }
 
 private fun logAddedVersionsKey(versionKey: String) {
-    println("Moved the current version to the versions.properties file under the following key:")
+    val versionsFileName = RefreshVersionsInternals.versionsPropertiesFile.name
+    println("Moved the current version to the $versionsFileName file under the following key:")
     print(AnsiColor.WHITE.boldHighIntensity)
     print(AnsiColor.YELLOW.background)
     print(versionKey)

--- a/sample-groovy/settings.gradle
+++ b/sample-groovy/settings.gradle
@@ -27,7 +27,7 @@ plugins {
     id("com.gradle.enterprise").version("3.1.1")
 }
 
-RefreshVersionsSetup.bootstrapRefreshVersions(settings)
+RefreshVersionsSetup.bootstrap(settings)
 
 gradleEnterprise {
     buildScan {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This new feature serves this use case: allow included/composite builds to share the version files, useful to migrate away from buildSrc.