### PR TITLE
✚ plural type-safe way of adding dependencies

### DIFF
--- a/plugins/core/src/main/kotlin/org/gradle/kotlin/dsl/dependencies.kt
+++ b/plugins/core/src/main/kotlin/org/gradle/kotlin/dsl/dependencies.kt
@@ -1,0 +1,27 @@
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
+fun DependencyHandler.`implementations`(vararg dependencies: String) =
+    implementations(dependencies.toList())
+
+fun DependencyHandler.`apis`(vararg dependencies: String) =
+    apis(dependencies.toList())
+
+fun DependencyHandler.`testImplementations`(vararg dependencies: String) =
+    testImplementations(dependencies.toList())
+
+fun DependencyHandler.`implementations`(dependencies: Iterable<String>) =
+    dependencies.forEach { dependencyNotation ->
+        add("implementation", dependencyNotation)
+    }
+
+fun DependencyHandler.`apis`(dependencies: Iterable<String>) =
+    dependencies.forEach { dependencyNotation ->
+        add("api", dependencyNotation)
+    }
+
+fun DependencyHandler.`testImplementations`(dependencies: Iterable<String>) =
+    dependencies.forEach { dependencyNotation ->
+        add("testImplementation", dependencyNotation)
+    }


### PR DESCRIPTION
Augment the Kotlin DSL for the block `dependencies { }`
with its plural forms `implementations`, `apis` and `testImplementations`.

For example:

```
dependencies {
  implementations(KotlinX.coroutines.core, KotlinX.coroutines.android)
}
```

This is both more concise and more type-safe.
`implementation(KotlinX.coroutines)` is wrong but would fail only at runtime because the method accept an object as parameter


<img width="625" alt="Voice____IdeaProjects_android_Voice__-_build_gradle_kts___data_" src="https://user-images.githubusercontent.com/459464/91301994-128c6680-e7a6-11ea-912b-2e9251f13c99.png">