### PR TITLE
✚ Add type safety to dependencies.implementation()

### DIFF
--- a/plugins/dependencies/src/main/kotlin/dependencies/AndroidX.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/AndroidX.kt
@@ -2,6 +2,7 @@
 
 import dependencies.DependencyNotationAndGroup
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 /**
  * Check changes from the latest AndroidX versions on
@@ -211,7 +212,7 @@ object AndroidX {
         @JvmField val animationTesting = "$artifactPrefix-animation-testing:_"
     }
 
-    object Lifecycle {
+    object Lifecycle: IsNotADependency {
         private const val artifactPrefix = "androidx.lifecycle:lifecycle"
 
         const val runtimeKtx = "$artifactPrefix-runtime-ktx:_"
@@ -240,7 +241,7 @@ object AndroidX {
         const val extensions = "$artifactPrefix-extensions:_"
     }
 
-    object Startup {
+    object Startup: IsNotADependency {
         const val runtime = "androidx.startup:startup-runtime:_"
     }
 
@@ -248,7 +249,7 @@ object AndroidX {
         @JvmField val extensions = "$artifactPrefix-extensions:_"
     }
 
-    object Security {
+    object Security: IsNotADependency {
         private const val artifactPrefix = "androidx.security:security"
 
         const val crypto = "$artifactPrefix-crypto:_"
@@ -257,7 +258,7 @@ object AndroidX {
         const val identityCredential = "$artifactPrefix-identity-credential:_"
     }
 
-    object Room {
+    object Room: IsNotADependency {
         private const val artifactPrefix = "androidx.room:room"
 
         const val ktx = "$artifactPrefix-ktx:_"
@@ -273,7 +274,7 @@ object AndroidX {
         const val rxJava2 = "$artifactPrefix-rxjava2:_"
     }
 
-    object Paging {
+    object Paging: IsNotADependency {
         private const val artifactPrefix = "androidx.paging:paging"
 
         const val commonKtx = "$artifactPrefix-common-ktx:_"
@@ -287,7 +288,7 @@ object AndroidX {
         const val rxJava2 = "$artifactPrefix-rxjava2:_"
     }
 
-    object Work {
+    object Work: IsNotADependency {
         const val runtimeKtx = "androidx.work:work-runtime-ktx:_"
 
         const val gcm = "androidx.work:work-gcm:_"
@@ -298,7 +299,7 @@ object AndroidX {
         const val rxJava2 = "androidx.work:work-rxjava2:_"
     }
 
-    object Navigation {
+    object Navigation: IsNotADependency {
         private const val artifactPrefix = "androidx.navigation:navigation"
 
         const val fragmentKtx = "$artifactPrefix-fragment-ktx:_"
@@ -320,13 +321,13 @@ object AndroidX {
     }
 
     @Incubating
-    object Ui {
+    object Ui: IsNotADependency {
         const val test = "androidx.ui:ui-test:_" // "Not Yet Refactored (no changes)" as of version 0.1.0-dev15.
         const val tooling = "androidx.ui:ui-tooling:_" // "Not Yet Refactored (no changes)" as of version 0.1.0-dev15.
     }
 
     @Incubating
-    object Compose {
+    object Compose: IsNotADependency {
         private const val groupPrefix = "androidx.compose"
 
         val runtime = Runtime
@@ -371,14 +372,14 @@ object AndroidX {
 
             val icons = Icons
 
-            object Icons {
+            object Icons: IsNotADependency {
                 @JvmField val core = "$artifactPrefix-icons-core:_"
                 @JvmField val extended = "$artifactPrefix-icons-extended:_"
             }
         }
     }
 
-    object Media2 {
+    object Media2: IsNotADependency {
         private const val artifactPrefix = "androidx.media2:media2"
 
         const val session = "$artifactPrefix-session:_"
@@ -389,7 +390,7 @@ object AndroidX {
         const val common = "$artifactPrefix-common:_"
     }
 
-    object Camera {
+    object Camera: IsNotADependency {
         private const val artifactPrefix = "androidx.camera:camera"
 
         const val core = "$artifactPrefix-core:_"
@@ -399,7 +400,7 @@ object AndroidX {
         const val view = "$artifactPrefix-view:_"
     }
 
-    object Hilt {
+    object Hilt: IsNotADependency {
         private const val artifactPrefix = "androidx.hilt:hilt"
 
         const val lifecycleViewModel = "$artifactPrefix-lifecycle-viewmodel:_"
@@ -407,14 +408,14 @@ object AndroidX {
         const val compiler = "$artifactPrefix-compiler:_"
     }
 
-    object Enterprise {
+    object Enterprise: IsNotADependency {
         private const val artifactPrefix = "androidx.enterprise:enterprise"
 
         const val feedback = "$artifactPrefix-feedback:_"
         const val feedbackTesting = "$artifactPrefix-feedback-testing:_"
     }
 
-    object Gaming {
+    object Gaming: IsNotADependency {
         private const val artifactPrefix = "androidx.gaming:gaming"
 
         const val framePacing = "$artifactPrefix-frame-pacing:_"
@@ -422,7 +423,7 @@ object AndroidX {
 
     }
 
-    object Slice {
+    object Slice: IsNotADependency {
         private const val artifactPrefix = "androidx.slice:slice"
 
         const val buildersKtx = "$artifactPrefix-builders-ktx:_"
@@ -432,7 +433,7 @@ object AndroidX {
         const val view = "$artifactPrefix-view:_"
     }
 
-    object Benchmark {
+    object Benchmark: IsNotADependency {
         private const val artifactPrefix = "androidx.benchmark:benchmark"
 
         const val junit4 = "$artifactPrefix-junit4:_"
@@ -442,7 +443,7 @@ object AndroidX {
         const val common = "$artifactPrefix-common:_"
     }
 
-    object Test {
+    object Test: IsNotADependency {
         private const val coreVersion = "_"
         private const val group = "androidx.test"
 
@@ -459,7 +460,7 @@ object AndroidX {
 
         val ext = Ext
 
-        object Ext {
+        object Ext: IsNotADependency {
             private const val extGroup = "androidx.test.ext"
             private const val extJunitVersion = "_"
 
@@ -474,7 +475,7 @@ object AndroidX {
         const val jankTestHelper = "$group.janktesthelper:janktesthelper:_"
         const val uiAutomator = "$group.uiautomator:uiautomator:_"
 
-        object Espresso {
+        object Espresso: IsNotADependency {
             private const val group = "androidx.test.espresso"
             private const val artifactPrefix = "$group:espresso"
 
@@ -488,7 +489,7 @@ object AndroidX {
             const val remote = "$artifactPrefix-remote:_"
             const val web = "$artifactPrefix-web:_"
 
-            object Idling {
+            object Idling: IsNotADependency {
                 private const val artifactPrefix = "$group.idling:idling"
 
                 const val concurrent = "$artifactPrefix-concurrent:_"
@@ -497,14 +498,14 @@ object AndroidX {
         }
     }
 
-    object Concurrent {
+    object Concurrent: IsNotADependency {
         private const val artifactPrefix = "androidx.concurrent:concurrent"
 
         const val futures = "$artifactPrefix-futures:_"
         const val futuresKtx = "$artifactPrefix-futures-ktx:_"
     }
 
-    object ArchCore {
+    object ArchCore: IsNotADependency {
         private const val artifactPrefix = "androidx.arch.core:core"
 
         const val common = "$artifactPrefix-common:_"
@@ -512,7 +513,7 @@ object AndroidX {
         const val testing = "$artifactPrefix-testing:_"
     }
 
-    object Legacy {
+    object Legacy: IsNotADependency {
         private const val artifactPrefix = "androidx.legacy:legacy"
 
         const val preferenceV14 = "$artifactPrefix-preference-v14:_"

--- a/plugins/dependencies/src/main/kotlin/dependencies/CashApp.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/CashApp.kt
@@ -1,5 +1,7 @@
 @file:Suppress("PackageDirectoryMismatch", "SpellCheckingInspection", "unused")
 
+import org.gradle.kotlin.dsl.IsNotADependency
+
 object CashApp {
 
     val sqlDelight = Square.sqlDelight
@@ -20,7 +22,7 @@ object CashApp {
      */
     val copper = Copper
 
-    object Copper {
+    object Copper: IsNotADependency {
         private const val artifactPrefix = "app.cash.copper:copper"
 
         const val flow = "$artifactPrefix-flow:_"

--- a/plugins/dependencies/src/main/kotlin/dependencies/DependencyNotationAndGroup.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/DependencyNotationAndGroup.kt
@@ -1,11 +1,9 @@
 package dependencies
 
-import org.gradle.kotlin.dsl.IsNotADependency
-
 abstract class DependencyNotationAndGroup(
     group: String,
     name: String
-) : CharSequence, IsNotADependency {
+) : CharSequence {
 
     protected val artifactPrefix = "$group:$name"
 

--- a/plugins/dependencies/src/main/kotlin/dependencies/DependencyNotationAndGroup.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/DependencyNotationAndGroup.kt
@@ -1,9 +1,11 @@
 package dependencies
 
+import org.gradle.kotlin.dsl.IsNotADependency
+
 abstract class DependencyNotationAndGroup(
     group: String,
     name: String
-) : CharSequence {
+) : CharSequence, IsNotADependency {
 
     protected val artifactPrefix = "$group:$name"
 

--- a/plugins/dependencies/src/main/kotlin/dependencies/Firebase.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Firebase.kt
@@ -1,6 +1,7 @@
 @file:Suppress("PackageDirectoryMismatch", "ObjectPropertyName", "SpellCheckingInspection")
 
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 /**
  * Firebase Android libraries.
@@ -101,7 +102,7 @@ interface Firebase {
     }
 }
 
-internal class FirebaseImpl(isBom: Boolean) : Firebase {
+internal class FirebaseImpl(isBom: Boolean) : Firebase, IsNotADependency {
 
     private val suffix = if (isBom) "" else ":_"
     private val artifactPrefix = "com.google.firebase:firebase"
@@ -125,12 +126,14 @@ internal class FirebaseImpl(isBom: Boolean) : Firebase {
     override val inAppMessagingDisplay = "$artifactPrefix-inappmessaging-display$suffix"
     override val inAppMessagingDisplayKtx = "$artifactPrefix-inappmessaging-display-ktx$suffix"
 
-    override val mlKit: Firebase.MlKit = object : Firebase.MlKit {
+    override val mlKit: Firebase.MlKit = object : Firebase.MlKit, IsNotADependency {
         private val mlArtifactPrefix = "$artifactPrefix-ml"
         override val vision = "$mlArtifactPrefix-vision$suffix"
         override val naturalLanguage = "$mlArtifactPrefix-natural-language$suffix"
-        override val models: Firebase.MlKit.Models = object : Firebase.MlKit.Models {
-            override val vision: Firebase.MlKit.Models.Vision = object : Firebase.MlKit.Models.Vision {
+
+        override val models: Firebase.MlKit.Models = object : Firebase.MlKit.Models, IsNotADependency {
+
+            override val vision: Firebase.MlKit.Models.Vision = object : Firebase.MlKit.Models.Vision, IsNotADependency {
                 private val artifactPrefix = "$mlArtifactPrefix-vision"
 
                 override val imageLabelling = "$artifactPrefix-image-label-model$suffix"
@@ -139,7 +142,7 @@ internal class FirebaseImpl(isBom: Boolean) : Firebase {
                 override val barcodeScanning = "$artifactPrefix-barcode-model$suffix"
                 override val autoMl = "$artifactPrefix-automl$suffix"
             }
-            override val naturalLanguage: Firebase.MlKit.Models.NaturalLanguage = object : Firebase.MlKit.Models.NaturalLanguage {
+            override val naturalLanguage: Firebase.MlKit.Models.NaturalLanguage = object : Firebase.MlKit.Models.NaturalLanguage, IsNotADependency {
                 private val artifactPrefix = "$mlArtifactPrefix-natural-language"
 
                 override val languageIdentification = "$artifactPrefix-language-id-model$suffix"

--- a/plugins/dependencies/src/main/kotlin/dependencies/Google.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Google.kt
@@ -2,6 +2,7 @@
 
 import dependencies.DependencyNotationAndGroup
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object Google {
@@ -14,7 +15,7 @@ object Google {
 
     val dagger = Dagger
 
-    object Android {
+    object Android: IsNotADependency {
         private const val artifactBase = "com.google.android"
 
         const val browserHelper = "com.google.androidbrowserhelper:androidbrowserhelper:_"
@@ -29,7 +30,7 @@ object Google {
         val playServices = PlayServices
         val play = Play
 
-        object PlayServices {
+        object PlayServices: IsNotADependency {
             private const val artifactPrefix = "$artifactBase.gms:play-services"
 
             /** Google Account Login */
@@ -93,7 +94,7 @@ object Google {
             const val wearOS = "$artifactPrefix-wearable:_"
         }
 
-        object Play {
+        object Play: IsNotADependency {
             private const val group = "$artifactBase.play"
 
             const val core = "$group:core:_"
@@ -101,7 +102,7 @@ object Google {
         }
     }
 
-    object Ar {
+    object Ar: IsNotADependency {
         private const val baseArtifact = "com.google.ar"
 
         /**
@@ -114,7 +115,7 @@ object Google {
          */
         val sceneform = Sceneform
 
-        object Sceneform {
+        object Sceneform: IsNotADependency {
             private const val artifactPrefix = "$baseArtifact.sceneform"
 
             const val animation = "$artifactPrefix:animation:_"
@@ -146,7 +147,7 @@ object Google {
         @Suppress("deprecation")
         val android = Android
 
-        object Hilt {
+        object Hilt: IsNotADependency {
             val android = Android
 
             object Android : DependencyNotationAndGroup(group = group, name = "hilt-android") {
@@ -169,7 +170,7 @@ object Google {
             @JvmField val support = "$artifactPrefix-support:_"
         }
 
-        object Grpc {
+        object Grpc: IsNotADependency {
             val server = Server
 
             object Server : DependencyNotationAndGroup(group = group, name = "dagger-grpc-server") {

--- a/plugins/dependencies/src/main/kotlin/dependencies/JakeWharton.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/JakeWharton.kt
@@ -5,6 +5,7 @@
 @file:Suppress("PackageDirectoryMismatch", "SpellCheckingInspection", "unused")
 
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object JakeWharton {
@@ -45,7 +46,7 @@ object JakeWharton {
 
         val converter = Converter
 
-        object Converter {
+        object Converter: IsNotADependency {
 
             /**
              * A Retrofit 2 `Converter.Factory` for [Kotlin serialization](https://github.com/Kotlin/kotlinx.serialization/).
@@ -56,7 +57,7 @@ object JakeWharton {
         }
     }
 
-    object Moshi {
+    object Moshi: IsNotADependency {
 
         /**
          * Shimo is a `JsonAdapter.Factory` for [Square.moshi] which randomizes the order of keys

--- a/plugins/dependencies/src/main/kotlin/dependencies/Kotlin.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Kotlin.kt
@@ -2,6 +2,7 @@
 
 import dependencies.DependencyNotationAndGroup
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object Kotlin {
@@ -16,7 +17,7 @@ object Kotlin {
         @JvmField val common = "$artifactPrefix-common:_"
     }
 
-    object Test {
+    object Test: IsNotADependency {
         private const val artifactPrefix = "org.jetbrains.kotlin:kotlin-test"
 
         const val annotationsCommon = "$artifactPrefix-annotations-common:_"

--- a/plugins/dependencies/src/main/kotlin/dependencies/KotlinX.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/KotlinX.kt
@@ -1,6 +1,7 @@
 @file:Suppress("PackageDirectoryMismatch", "SpellCheckingInspection", "unused")
 
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object KotlinX {
@@ -16,7 +17,7 @@ object KotlinX {
 
     val reflect = Reflect
 
-    object Coroutines {
+    object Coroutines: IsNotADependency {
         private const val artifactPrefix = "$artifactBase-coroutines"
 
         const val core = "$artifactPrefix-core:_"
@@ -46,7 +47,7 @@ object KotlinX {
         const val test = "$artifactPrefix-test:_"
     }
 
-    object Serialization {
+    object Serialization: IsNotADependency {
         private const val artifactPrefix = "$artifactBase-serialization"
 
         const val core = "$artifactPrefix-core:_"
@@ -70,7 +71,7 @@ object KotlinX {
         //endregion
     }
 
-    object Collections {
+    object Collections: IsNotADependency {
         private const val immutableArtifactPrefix = "$artifactBase-collections-immutable"
 
         const val immutable = "$immutableArtifactPrefix:_"
@@ -78,20 +79,20 @@ object KotlinX {
         const val immutableJvmOnly = "$immutableArtifactPrefix-jvm:_"
     }
 
-    object Html {
+    object Html: IsNotADependency {
         private const val artifactPrefix = "$artifactBase-html"
 
         const val jvm = "$artifactPrefix-jvm:_"
         const val js = "$artifactPrefix-js:_"
     }
 
-    object Io {
+    object Io: IsNotADependency {
         private const val artifactPrefix = "$artifactBase-io"
 
         const val jvm = "$artifactPrefix-jvm:_"
     }
 
-    object Reflect {
+    object Reflect: IsNotADependency {
         const val lite = "$artifactBase.reflect.lite:_"
     }
 }

--- a/plugins/dependencies/src/main/kotlin/dependencies/Ktor.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Ktor.kt
@@ -1,6 +1,7 @@
 @file:Suppress("PackageDirectoryMismatch", "SpellCheckingInspection", "unused", "MemberVisibilityCanBePrivate")
 
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 /**
  * [Complete KDoc here](https://api.ktor.io/latest/).
@@ -42,7 +43,7 @@ object Ktor {
 
     const val utils = "$artifactBase-utils:_"
 
-    object Client {
+    object Client: IsNotADependency {
         private const val artifactPrefix = "$artifactBase-client"
 
         const val core = "$artifactPrefix-core:_"
@@ -98,7 +99,7 @@ object Ktor {
         const val android = "$artifactPrefix-android:_"
     }
 
-    object Features {
+    object Features: IsNotADependency {
         /** As of ktor 1.3.0, supports JVM only. */
         const val auth = "$artifactBase-auth:_"
 
@@ -185,7 +186,7 @@ object Ktor {
     /**
      * As of ktor 1.3.0, ktor server artifacts support only the JVM.
      */
-    object Server {
+    object Server: IsNotADependency {
         private const val artifactPrefix = "$artifactBase-server"
 
         /**
@@ -219,7 +220,7 @@ object Ktor {
         const val testHost = "$artifactPrefix-test-host:_"
     }
 
-    object Network {
+    object Network: IsNotADependency {
         private const val artifactPrefix = "$artifactBase-network"
 
         /**

--- a/plugins/dependencies/src/main/kotlin/dependencies/Orchid.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Orchid.kt
@@ -1,6 +1,7 @@
 @file:Suppress("PackageDirectoryMismatch", "SpellCheckingInspection", "unused")
 
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object Orchid {
@@ -11,7 +12,7 @@ object Orchid {
     const val test = "$groupId:OrchidTest:_"
 
     val plugins = Plugins
-    object Plugins {
+    object Plugins: IsNotADependency {
         const val changelog         = "$groupId:OrchidChangelog:_"
         const val forms             = "$groupId:OrchidForms:_"
         const val groovydoc         = "$groupId:OrchidGroovydoc:_"
@@ -42,7 +43,7 @@ object Orchid {
     }
 
     val themes = Themes
-    object Themes {
+    object Themes: IsNotADependency {
         const val bsDoc           = "$groupId:OrchidBsDoc:_"
         const val copper          = "$groupId:OrchidCopper:_"
         const val editorial       = "$groupId:OrchidEditorial:_"
@@ -50,7 +51,7 @@ object Orchid {
     }
 
     val bundles = Bundles
-    object Bundles {
+    object Bundles: IsNotADependency {
         const val all          = "$groupId:OrchidAll:_"
         const val blog         = "$groupId:OrchidBlog:_"
         const val docs         = "$groupId:OrchidDocs:_"

--- a/plugins/dependencies/src/main/kotlin/dependencies/Splitties.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Splitties.kt
@@ -1,6 +1,7 @@
 @file:Suppress("PackageDirectoryMismatch", "SpellCheckingInspection", "unused")
 
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object Splitties {
@@ -8,7 +9,7 @@ object Splitties {
 
     private const val artifactPrefix = "com.louiscad.splitties:splitties"
 
-    object Packs {
+    object Packs: IsNotADependency {
         const val androidBase = "$artifactPrefix-fun-pack-android-base:_"
         const val androidBaseWithViewsDsl = "$artifactPrefix-fun-pack-android-base-with-views-dsl:_"
         const val appCompat = "$artifactPrefix-fun-pack-android-appcompat:_"

--- a/plugins/dependencies/src/main/kotlin/dependencies/Square.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Square.kt
@@ -2,6 +2,7 @@
 
 import dependencies.DependencyNotationAndGroup
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object Square {
@@ -50,14 +51,14 @@ object Square {
 
     const val okio = "com.squareup.okio:okio:_"
 
-    object OkHttp3 {
+    object OkHttp3: IsNotADependency {
         private const val group = "com.squareup.okhttp3"
         const val okHttp = "$group:okhttp:_"
         const val loggingInterceptor = "$group:logging-interceptor:_"
         const val mockWebServer = "$group:mockwebserver:_"
     }
 
-    object Retrofit2 {
+    object Retrofit2: IsNotADependency {
         private const val group = "com.squareup.retrofit2"
 
         const val retrofit = "$group:retrofit:_"
@@ -66,7 +67,7 @@ object Square {
         val converter = Converter
         val adapter = Adapter
 
-        object Converter {
+        object Converter: IsNotADependency {
             private const val artifactPrefix = "$group:converter"
 
             const val scalars = "$artifactPrefix-scalars:_"
@@ -78,7 +79,7 @@ object Square {
             const val simpleXml = "$artifactPrefix-simplexml:_"
         }
 
-        object Adapter {
+        object Adapter: IsNotADependency {
             const val java8 = "$group:adapter-java8:_"
             const val rxJava1 = "$group:adapter-rxjava:_"
             const val rxJava2 = "$group:adapter-rxjava2:_"
@@ -86,7 +87,7 @@ object Square {
         }
     }
 
-    object SqlDelight {
+    object SqlDelight: IsNotADependency {
         private const val group = "com.squareup.sqldelight"
 
         const val gradlePlugin = "$group:gradle-plugin:_"
@@ -95,7 +96,7 @@ object Square {
 
         const val coroutinesExtensions = "$group:coroutines-extensions"
 
-        object Drivers {
+        object Drivers: IsNotADependency {
             const val android = "$group:android-driver:_"
 
             const val jdbc = "$group:jdbc-driver:_"
@@ -111,7 +112,7 @@ object Square {
         @JvmField val javaReflect = backingString
     }
 
-    object Wire {
+    object Wire: IsNotADependency {
         private const val artifactPrefix = "com.squareup.wire:wire"
 
         const val gradlePlugin = "$artifactPrefix-gradle-plugin:_"
@@ -119,12 +120,12 @@ object Square {
         const val runtime = "$artifactPrefix-runtime:_"
         val grpc = Grpc
 
-        object Grpc {
+        object Grpc: IsNotADependency {
             const val client = "$artifactPrefix-grpc-client:_"
         }
     }
 
-    object LeakCanary {
+    object LeakCanary: IsNotADependency {
         private const val group = "com.squareup.leakcanary"
 
         /**

--- a/plugins/dependencies/src/main/kotlin/dependencies/Testing.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Testing.kt
@@ -6,6 +6,7 @@
 
 import dependencies.DependencyNotationAndGroup
 import org.gradle.api.Incubating
+import org.gradle.kotlin.dsl.IsNotADependency
 
 @Incubating
 object Testing {
@@ -18,7 +19,7 @@ object Testing {
     const val junit4 = "junit:junit:_"
 
     val junit = JunitJupiter
-    
+
     val kotest = Kotest
 
     val spek = Spek
@@ -51,7 +52,7 @@ object Testing {
      *
      * GitHub page: [kotest/kotest](https://github.com/kotest/kotest)
      */
-    object Kotest {
+    object Kotest: IsNotADependency {
         private const val artifactBase = "io.kotest:kotest"
 
         val runner = Runner
@@ -61,22 +62,22 @@ object Testing {
 
         const val core = "$artifactBase-core:_"
         const val property = "$artifactBase-property:_"
-        const val propertyArrow = "$artifactBase-property-arrow:_"    
+        const val propertyArrow = "$artifactBase-property-arrow:_"
 
-        object Runner {
+        object Runner: IsNotADependency {
             private const val artifactPrefix = "$artifactBase-runner"
 
             const val junit4 = "$artifactPrefix-junit4:_"
             const val junit5 = "$artifactPrefix-junit5:_"
         }
 
-        object Plugins {
+        object Plugins: IsNotADependency {
             private const val artifactPrefix = "$artifactBase-plugins"
 
             const val piTest = "$artifactPrefix-pitest:_"
         }
 
-        object Extensions {
+        object Extensions: IsNotADependency {
             private const val artifactPrefix = "$artifactBase-extensions"
 
             const val spring = "$artifactPrefix-spring:_"
@@ -87,9 +88,9 @@ object Testing {
             const val mockServer = "$artifactPrefix-mockserver:_"
         }
 
-        object Assertions {
+        object Assertions: IsNotADependency {
             private const val artifactPrefix = "$artifactBase-assertions"
-            
+
             const val core = "$artifactPrefix-core:_"
             const val ktor = "$artifactPrefix-ktor:_"
             const val json = "$artifactPrefix-json:_"
@@ -100,22 +101,22 @@ object Testing {
             const val sql = "$artifactPrefix-sql:_"
             const val compiler = "$artifactPrefix-compiler:_"
         }
-    }    
-    
+    }
+
     /**
      * A specification framework for Kotlin
      *
      * Official website :[spekframework.org](https://www.spekframework.org)
      * GitHub page: [spekframework/spek](https://github.com/spekframework/spek/)
      */
-    object Spek {
+    object Spek: IsNotADependency {
         private const val artifactBase = "org.spekframework.spek2:spek"
 
         val dsl = Dsl
         val runner = Runner
         val runtime = Runtime
 
-        object Dsl {
+        object Dsl: IsNotADependency {
             private const val artifactPrefix = "$artifactBase-dsl"
 
             const val jvm = "$artifactPrefix-jvm:_"
@@ -124,7 +125,7 @@ object Testing {
 
             val native = Native
 
-            object Native {
+            object Native: IsNotADependency {
                 private const val prefix = "$artifactPrefix-native"
                 const val linux = "$prefix-linux:_"
                 const val macos = "$prefix-macos:_"
@@ -132,13 +133,13 @@ object Testing {
             }
         }
 
-        object Runner {
+        object Runner: IsNotADependency {
             private const val artifactPrefix = "$artifactBase-runner"
 
             const val junit5 = "$artifactPrefix-junit5:_"
         }
 
-        object Runtime {
+        object Runtime: IsNotADependency {
             private const val artifactPrefix = "$artifactBase-runtime"
 
             const val jvm = "$artifactPrefix-jvm:_"
@@ -153,7 +154,7 @@ object Testing {
      *
      * GitHub page: [robfletcher/strikt](https://github.com/robfletcher/strikt)
      */
-    object Strikt {
+    object Strikt: IsNotADependency {
         private const val artifactPrefix = "io.strikt:strikt"
 
         const val bom = "$artifactPrefix-bom:_"
@@ -186,7 +187,7 @@ object Testing {
      *
      * GitHub page: [mockito/mockito](https://github.com/mockito/mockito).
      */
-    object Mockito {
+    object Mockito: IsNotADependency {
         private const val artifactPrefix = "org.mockito:mockito"
 
         const val core = "$artifactPrefix-core:_"

--- a/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
+++ b/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
@@ -6,24 +6,30 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 
 /**
- * Marker interface that prevents the user to add a wrong dependency like
+ * Marker interface that prevents the user to add a wrong dependency
+ * so that the IDE can show a warning
  *
+ * ```
+ * dependencies {
  *     implementation(Testing.kotest)
- *                   ^^^^^^^^^^^^^^^
- *                   IDE: This is not a valid dependency notation but a group of dependency notations
+ *                   ^^^^^^^^^^^^^^
+ *        This is not a valid dependency notation but a group of dependency notations
+ * }
+ * ```
  */
 interface IsNotADependency
 
-const val ErrorIsNotADependency = """This is not a valid dependency notation but a group of dependency notations"""
+private const val ErrorIsNotADependency =
+    """This is not a valid dependency notation but a group of dependency notations"""
 
-@kotlin.Deprecated(ErrorIsNotADependency)
+@Deprecated(ErrorIsNotADependency)
 fun DependencyHandler.`implementation`(dependencyNotation: IsNotADependency): Dependency? =
     null
 
-@kotlin.Deprecated(ErrorIsNotADependency)
+@Deprecated(ErrorIsNotADependency)
 fun DependencyHandler.`api`(dependencyNotation: IsNotADependency): Dependency? =
     null
 
-@kotlin.Deprecated(ErrorIsNotADependency)
+@Deprecated(ErrorIsNotADependency)
 fun DependencyHandler.`testImplementation`(dependencyNotation: IsNotADependency): Dependency? =
     null

--- a/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
+++ b/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
@@ -5,6 +5,11 @@ package org.gradle.kotlin.dsl
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 
+/**
+ * Marker interface that prevents the user to add a wrong dependency like
+ *     implementation(AndroidX.core)
+ * Since AndroidX.core IsNotADependency, the IDE will show a warning
+ */
 interface IsNotADependency
 
 const val ErrorIsNotADependency = """This is not a valid dependency notation but a group of dependency notations"""

--- a/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
+++ b/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
@@ -1,0 +1,22 @@
+@file:Suppress("DeprecatedCallableAddReplaceWith")
+
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
+interface IsNotADependency
+
+const val ErrorIsNotADependency = """This is not a valid dependency notation but a group of dependency notations"""
+
+@kotlin.Deprecated(ErrorIsNotADependency)
+fun DependencyHandler.`implementation`(dependencyNotation: IsNotADependency): Dependency? =
+    null
+
+@kotlin.Deprecated(ErrorIsNotADependency)
+fun DependencyHandler.`api`(dependencyNotation: IsNotADependency): Dependency? =
+    null
+
+@kotlin.Deprecated(ErrorIsNotADependency)
+fun DependencyHandler.`testImplementation`(dependencyNotation: IsNotADependency): Dependency? =
+    null

--- a/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
+++ b/plugins/dependencies/src/main/kotlin/org/gradle/kotlin/dsl/IsNotADependency.kt
@@ -7,8 +7,10 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 
 /**
  * Marker interface that prevents the user to add a wrong dependency like
- *     implementation(AndroidX.core)
- * Since AndroidX.core IsNotADependency, the IDE will show a warning
+ *
+ *     implementation(Testing.kotest)
+ *                   ^^^^^^^^^^^^^^^
+ *                   IDE: This is not a valid dependency notation but a group of dependency notations
  */
 interface IsNotADependency
 


### PR DESCRIPTION
This is a follow up on https://github.com/jmfayard/refreshVersions/pull/229

It focuses on typesafety only

There is an elegant Kotlin solution for every problem.

The IDE now imports two version of `implementation`. 

```
fun DependencyHandler.`implementation`(dependencyNotation: Any): Dependency? =
    add("implementation", dependencyNotation)

@kotlin.Deprecated(ErrorIsNotADependency)
fun DependencyHandler.`implementation`(dependencyNotation: IsNotADependency): Dependency? =
    null
```

Since the second one is more specific, it takes precedence when the parameter is `IsNotADependency` or in practice `DependencyNotationAndGroup`

This way the IDE shows you that made a mistake

<img width="874" alt="GraySky____IdeaProjects_gray-sky-weather__-_build_gradle_kts___app_" src="https://user-images.githubusercontent.com/459464/91646121-1b9e6180-ea4c-11ea-87b1-c18cd08c63b1.png">
