### PR TITLE
Auto reset static state

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -47,7 +47,6 @@ fun Settings.bootstrapRefreshVersionsCore(
                 "bootstrapRefreshVersionsCoreForBuildSrc() instead (Kotlin DSL)," +
                 "or RefreshVersionsCoreSetup.bootstrapForBuildSrc() if you're using Groovy DSL."
     }
-    UsedPluginsHolder.clear()
     RefreshVersionsConfigHolder.initialize(
         settings = settings,
         artifactVersionKeyRules = artifactVersionKeyRules,

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/ResettableLateInitDelegate.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/ResettableLateInitDelegate.kt
@@ -1,0 +1,75 @@
+package de.fayard.refreshVersions.core.internal
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+internal class ResettableDelegates {
+
+    fun reset() {
+        associatedDelegates.forEach {
+            with(it) { with(null) { reset() } }
+        }
+    }
+
+    inner class NullableDelegate<T> : Delegate<T?>() {
+
+        override fun getValue(thisRef: Any?, property: KProperty<*>): T? = field
+
+        operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {
+            field = value
+        }
+
+        override fun Nothing?.reset() {
+            field = null
+        }
+
+        private var field: T? = null
+
+        init {
+            associatedDelegates.add(this)
+        }
+    }
+
+    inner class LateInit<T : Any> : Delegate<T>() {
+
+        val isInitialized: Boolean get() = this.field != null
+
+        override fun getValue(thisRef: Any?, property: KProperty<*>): T = field ?: error(
+            "Property ${property.name} not initialized yet! " +
+                    "Has it been used after reset or before init?"
+        )
+
+        operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+            field = value
+        }
+
+        override fun Nothing?.reset() {
+            field = null
+        }
+
+        private var field: T? = null
+
+        init {
+            associatedDelegates.add(this)
+        }
+    }
+
+    inner class Lazy<T : Any>(private val initializer: () -> T) : Delegate<T>() {
+
+        private var value: T? = null
+
+        override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+            return value ?: initializer().apply { value = this }
+        }
+
+        override fun Nothing?.reset() {
+            value = null
+        }
+    }
+
+    abstract class Delegate<T> : ReadOnlyProperty<Any?, T> {
+        abstract fun Nothing?.reset()
+    }
+
+    private val associatedDelegates = mutableListOf<Delegate<*>>()
+}

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/UsedPluginsHolder.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/UsedPluginsHolder.kt
@@ -6,10 +6,6 @@ import org.gradle.api.internal.artifacts.dependencies.AbstractDependency
 
 internal object UsedPluginsHolder {
 
-    fun clear() {
-        usedPluginDependencies.clear()
-    }
-
     fun noteUsedPluginDependency(
         dependencyNotation: String,
         repositories: ArtifactRepositoryContainer
@@ -35,7 +31,9 @@ internal object UsedPluginsHolder {
         val repositories: ArtifactRepositoryContainer
     )
 
-    private val usedPluginDependencies = mutableListOf<UsedPluginDependency>()
+    private val usedPluginDependencies by RefreshVersionsConfigHolder.resettableDelegates.Lazy {
+        mutableListOf<UsedPluginDependency>()
+    }
 
     private class ConfigurationLessDependency(val dependencyNotation: String) : AbstractDependency() {
 


### PR DESCRIPTION
I'm adding delegates to make it easy to have top level properties or object properties be automatically reset when the Gradle build is finished.

Now, everytime we add a top level property or a property in an object/singleton, we need to delegate it with one of the delegates in `RefreshVersionsConfigHolder.resettableDelegates` to ensure it's auto-reset.

I'm merging this straightaway but the discussion is still open in this PR should we make further improvements or changes.