### PR TITLE
Refactor Compose Compiler Group (1.0.0-alpha04)

### DIFF
--- a/plugins/dependencies/src/main/kotlin/dependencies/AndroidX.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/AndroidX.kt
@@ -336,7 +336,7 @@ object AndroidX {
         val material = Material
 
         @Incubating
-        const val compiler = "androidx.compose:compose-compiler:_" // "Not Yet Refactored (no changes)" as of version 0.1.0-dev15.
+        const val compiler = "androidx.compose.compiler:compiler:_" // "Not Yet Refactored (no changes)" as of version 0.1.0-dev15.
 
         object Runtime : DependencyNotationAndGroup(group = "$groupPrefix.runtime", name = "runtime") {
 


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Compose compiler group has refactored in 1.0.0-alpha04
Reference : https://developer.android.com/jetpack/androidx/releases/compose-compiler

> `androidx.compose:compose-compiler` has been refactored to `androidx.compose.compiler:compiler`. This is the first release in the new group.