### PR TITLE
✚ We support Gradle >= 6.3

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -8,6 +8,8 @@ import de.fayard.refreshVersions.core.internal.resolveVersion
 import de.fayard.refreshVersions.core.internal.setupVersionPlaceholdersResolving
 import org.gradle.api.initialization.Settings
 import org.gradle.kotlin.dsl.apply
+import org.gradle.tooling.UnsupportedVersionException
+import org.gradle.util.GradleVersion
 import java.io.File
 
 /**
@@ -42,6 +44,10 @@ fun Settings.bootstrapRefreshVersionsCore(
     artifactVersionKeyRules: List<String> = emptyList(),
     versionsPropertiesFile: File = rootDir.resolve("versions.properties")
 ) {
+    val supportedGradleVersion = "6.3" // 6.2 fail with this error: https://gradle.com/s/shp7hbtd3i3ii
+    if (GradleVersion.current() < GradleVersion.version(supportedGradleVersion)) {
+        throw UnsupportedVersionException("""The plugin "de.fayard.refreshVersions" only works with Gradle $supportedGradleVersion and above.""")
+    }
     require(settings.isBuildSrc.not()) {
         "This bootstrap is only for the root project. For buildSrc, please call " +
                 "bootstrapRefreshVersionsCoreForBuildSrc() instead (Kotlin DSL)," +


### PR DESCRIPTION
In Gradle 6.2, the task refreshVersions fail with this error:

org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':refreshVersions'.
Caused by: java.lang.NoClassDefFoundError: kotlin/coroutines/AbstractCoroutineContextKey

https://gradle.com/s/shp7hbtd3i3ii

How I tested the thing:

```
$ echo "Install SDK man"
$ open https://sdkman.io/
$ sdk install gradle 6.2
$ sdk use gradle 6.2
$ cd sample-kotlin
$ gradle help
FAILURE: Build failed with an exception.

* Where:
Settings file '/Users/jmfayard/IdeaProjects/refreshVersions/sample-kotlin/settings.gradle.kts' line: 28

* What went wrong:
The plugin "de.fayard.refreshVersions" only works with Gradle 6.3 and above.
```