### PR TITLE
WIP: allows using plugins without marker

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,15 @@
+# https://jitpack.io/docs/BUILDING/
+# implementation 'com.github.jmfayard:refreshVersions:Tag'
+jdk:
+  - openjdk8
+#before_install:
+#  - ./custom_setup.sh
+install:
+  - echo "implementation(com.github.$GROUP:$ARTIFACT:$VERSION-SNAPSHOT)"
+  - echo "See https://jitpack.io/com/github/$GROUP/$ARTIFACT/$VERSION/"
+  - echo "Logs at https://jitpack.io/com/github/$GROUP/$ARTIFACT/$VERSION/build.log"
+  - cd plugins
+  - ./gradlew publishToMavenLocal
+  - cd ../
+#env:
+#  MYVAR: "custom environment variable"

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/CurrentlyUsedVersion.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/CurrentlyUsedVersion.kt
@@ -5,6 +5,8 @@ import org.gradle.api.initialization.Settings
 @InternalRefreshVersionsApi
 fun Settings.currentVersionOfRefreshVersions(): String {
     return buildscript.configurations.flatMap { it.dependencies }.single {
-        it.group == "de.fayard.refreshVersions"
+        val useJitpack = "${it.group}".startsWith("com.github.")
+            && it.name == "refreshVersions" // See https://gradle.com/s/u6p6roznt4kn6
+        it.group == "de.fayard.refreshVersions" || useJitpack
     }.version!!
 }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
@@ -3,7 +3,8 @@ package de.fayard.refreshVersions.core.internal.versions
 internal actual data class VersionsPropertiesModel(
     actual val preHeaderContent: String,
     actual val generatedByVersion: String,
-    actual val sections: List<Section>
+    actual val sections: List<Section>,
+    actual val pluginResolution: (id: String, String) -> String?
 ) {
     init {
         if (preHeaderContent.isNotEmpty()) require(preHeaderContent.endsWith('\n'))

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModelH.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModelH.kt
@@ -4,6 +4,7 @@ internal expect class VersionsPropertiesModel {
     val preHeaderContent: String
     val generatedByVersion: String
     val sections: List<Section>
+    val pluginResolution: (id: String, String) -> String?
 
     sealed class Section {
         class Comment : Section {

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesReading.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesReading.kt
@@ -69,7 +69,8 @@ private fun VersionsPropertiesModel.Companion.readFromTextInternal(
     return VersionsPropertiesModel(
         preHeaderContent = preHeaderContent,
         generatedByVersion = generatedByVersion,
-        sections = sections
+        sections = sections,
+        pluginResolution = { _, _ -> null }
     )
 }
 

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
@@ -39,7 +39,8 @@ import java.io.File
 @JvmName("bootstrap")
 fun Settings.bootstrapRefreshVersions(
     extraArtifactVersionKeyRules: List<String> = emptyList(),
-    versionsPropertiesFile: File = rootDir.resolve("versions.properties")
+    versionsPropertiesFile: File = rootDir.resolve("versions.properties"),
+    pluginResolution: (id: String, String) -> String? = { _, _ -> null}
 ) {
     require(settings.isBuildSrc.not()) {
         "This bootstrap is only for the root project. For buildSrc, please call " +
@@ -52,7 +53,8 @@ fun Settings.bootstrapRefreshVersions(
         } else {
             RefreshVersionsPlugin.artifactVersionKeyRules + extraArtifactVersionKeyRules
         },
-        versionsPropertiesFile = versionsPropertiesFile
+        versionsPropertiesFile = versionsPropertiesFile,
+        pluginResolution = pluginResolution
     )
     gradle.rootProject {
         apply<RefreshVersionsPlugin>()

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
@@ -40,7 +40,7 @@ import java.io.File
 fun Settings.bootstrapRefreshVersions(
     extraArtifactVersionKeyRules: List<String> = emptyList(),
     versionsPropertiesFile: File = rootDir.resolve("versions.properties"),
-    pluginResolution: (id: String, String) -> String? = { _, _ -> null}
+    pluginResolution: (id: String) -> String? = { null }
 ) {
     require(settings.isBuildSrc.not()) {
         "This bootstrap is only for the root project. For buildSrc, please call " +


### PR DESCRIPTION
this is something i hacked together because i could not figure out how to make use of `pluginManagement.resolutionStrategy.eachPlugin` properly since refreshVersions seems to override it

so instead a lambda is passed to the refreshVersions call

usage:

```
bootstrapRefreshVersions(
    pluginResolution = { pluginId, version ->
        logger.lifecycle("picking group and name for $pluginId with version $version")
        when (pluginId) {
            "com.android.application", "com.android.library" -> "com.android.tools.build:gradle"
            "kotlin-android", "kotlin-kapt", "kotlin-android-extensions" -> "org.jetbrains.kotlin:kotlin-gradle-plugin"
            "androidx.navigation.safeargs.kotlin" -> "androidx.navigation:navigation-safe-args-gradle-plugin"
            "com.google.gms.google-services" -> "com.google.gms:google-services"
            "realm-android" -> "io.realm:realm-gradle-plugin"
            "de.mannodermaus.android-junit5" -> "de.mannodermaus.gradle.plugins:android-junit5"
            else -> null
        }
    }
)
```