### PR TITLE
Fixes maven authentication

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/extensions/gradle/AuthenticationSupported.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/extensions/gradle/AuthenticationSupported.kt
@@ -9,5 +9,5 @@ val AuthenticationSupported.passwordCredentials: PasswordCredentials?
     // https://github.com/gradle/gradle/issues/14694
     get() = runCatching {
         // We use runCatching to avoid crashing the build if the internal APIs change.
-        (this as AuthenticationSupportedInternal?)?.configuredCredentials as? PasswordCredentials
+        (this as AuthenticationSupportedInternal?)?.configuredCredentials?.orNull as? PasswordCredentials
     }.getOrNull()


### PR DESCRIPTION
Fixes #288 
Fixes #320 

configuredCredentials returns Property<Credentials>, hence we need to get the value to obtain PasswordCredentials.