### PR TITLE
Add version placeholder to material compose theme adapter

### DIFF
--- a/plugins/dependencies/src/main/kotlin/dependencies/Google.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Google.kt
@@ -54,7 +54,7 @@ object Google {
         val material = Material
 
         object Material : DependencyNotationAndGroup(group = "$artifactBase.material", name = "material") {
-            @JvmField val composeThemeAdapter = "$artifactBase.material:compose-theme-adapter"
+            @JvmField val composeThemeAdapter = "$artifactBase.material:compose-theme-adapter:_"
         }
 
         private const val wearOsVersion = "_"


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
`Google.android.material.composeThemeAdapter` was missing a version placeholder, so I added it.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [guidelines for the development process](https://jmfayard.github.io/refreshVersions/contributing/submitting-prs/dev-process/)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
