### PR TITLE
Detection of BoM usage doesn't work

### DIFF
--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -27,6 +27,10 @@ repositories {
 }
 
 dependencies {
+    implementation(Firebase.analytics)
+    implementation(platform(Firebase.bom))
+    implementation(Firebase.analyticsKtx)
+
     implementation(AndroidX.core)
     testImplementation(KotlinX.coroutines.core)
     testImplementation(KotlinX.coroutines.jdk8)

--- a/sample-kotlin/versions.properties
+++ b/sample-kotlin/versions.properties
@@ -15,6 +15,8 @@ plugin.org.jetbrains.kotlinx.benchmark=0.3.0
 ## unused
 plugin.com.example.unused=42
 
+version.firebase-bom=28.3.1
+
 ## unused
 version.unused=42
 


### PR DESCRIPTION
Now that the creation of DependencyNotation-s is not lazy, the detection of BoM usage doesn't work. 

The following change to build.gradle.kts should throw an error  but doens't