### PR TITLE
Implement automatic migration when a version key rule is added, edited, or removed

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCleanupTask.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCleanupTask.kt
@@ -4,7 +4,7 @@ import de.fayard.refreshVersions.core.internal.RefreshVersionsConfigHolder
 import de.fayard.refreshVersions.core.internal.SettingsPluginsUpdater.removeCommentsAddedByUs
 import de.fayard.refreshVersions.core.internal.versions.VersionsPropertiesModel
 import de.fayard.refreshVersions.core.internal.versions.VersionsPropertiesModel.Section
-import de.fayard.refreshVersions.core.internal.versions.readFrom
+import de.fayard.refreshVersions.core.internal.versions.readFromFile
 import de.fayard.refreshVersions.core.internal.versions.writeTo
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
@@ -13,7 +13,7 @@ open class RefreshVersionsCleanupTask : DefaultTask() {
 
     @TaskAction
     fun cleanUpVersionsProperties() {
-        val model = VersionsPropertiesModel.readFrom(RefreshVersionsConfigHolder.versionsPropertiesFile)
+        val model = VersionsPropertiesModel.readFromFile(RefreshVersionsConfigHolder.versionsPropertiesFile)
 
         val sectionsWithoutAvailableUpdates = model.sections.map { section ->
             when (section) {

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -44,7 +44,8 @@ import java.io.File
 @JvmName("bootstrap")
 fun Settings.bootstrapRefreshVersionsCore(
     artifactVersionKeyRules: List<String> = emptyList(),
-    versionsPropertiesFile: File = rootDir.resolve("versions.properties")
+    versionsPropertiesFile: File = rootDir.resolve("versions.properties"),
+    getRemovedDependenciesVersionsKeys: () -> Map<ModuleId.Maven, String> = { emptyMap() }
 ) {
     require(settings.isBuildSrc.not()) {
         "This bootstrap is only for the root project. For buildSrc, please call " +
@@ -54,6 +55,7 @@ fun Settings.bootstrapRefreshVersionsCore(
     RefreshVersionsConfigHolder.initialize(
         settings = settings,
         artifactVersionKeyRules = artifactVersionKeyRules,
+        getRemovedDependenciesVersionsKeys = getRemovedDependenciesVersionsKeys,
         versionsPropertiesFile = versionsPropertiesFile
     )
     setupRefreshVersions(settings = settings)

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesReading.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesReading.kt
@@ -3,10 +3,11 @@ package de.fayard.refreshVersions.core.internal.versions
 import de.fayard.refreshVersions.core.extensions.sequences.uniqueBy
 import de.fayard.refreshVersions.core.extensions.text.substringAfterLastLineStartingWith
 import de.fayard.refreshVersions.core.extensions.text.substringBetween
+import de.fayard.refreshVersions.core.internal.RefreshVersionsConfigHolder
 import java.io.File
 
-internal fun VersionsPropertiesModel.Companion.readFrom(
-    versionsPropertiesFile: File
+internal fun VersionsPropertiesModel.Companion.readFromFile(
+    versionsPropertiesFile: File = RefreshVersionsConfigHolder.versionsPropertiesFile
 ): VersionsPropertiesModel {
     val text = synchronized(versionsPropertiesFileLock) { versionsPropertiesFile.readText() }
     return readFromText(text)

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesWriting.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesWriting.kt
@@ -96,7 +96,7 @@ private inline fun VersionsPropertiesModel.Companion.update(
 ) {
     require(versionsPropertiesFile.name == "versions.properties")
     synchronized(versionsPropertiesFileLock) {
-        val newModel = transform(VersionsPropertiesModel.readFrom(versionsPropertiesFile))
+        val newModel = transform(VersionsPropertiesModel.readFromFile(versionsPropertiesFile))
         newModel.writeTo(versionsPropertiesFile)
     }
 }

--- a/plugins/dependencies/src/test/kotlin/de/fayard/refreshVersions/BundledDependenciesTest.kt
+++ b/plugins/dependencies/src/test/kotlin/de/fayard/refreshVersions/BundledDependenciesTest.kt
@@ -53,12 +53,13 @@ class BundledDependenciesTest {
     }
 
     @Test
-    fun `We should not change version keys`() {
+    fun `Version keys should be up to date`() {
         val rulesDir = mainResources.resolve("refreshVersions-rules")
         val versionKeyReader = ArtifactVersionKeyReader.fromRules(rulesDir.listFiles()!!.map { it.readText() })
 
         val existingKeys = testResources.resolve("dependencies-versions-key-validated.txt")
         val receivedKeys = testResources.resolve("dependencies-versions-key-received.txt")
+        val removedKeys = mainResources.resolve("removed-dependencies-versions-keys.txt")
 
         val existingMapping = existingKeys.readLines().mapNotNull { DependencyMapping.fromLine(it) }
         val receivedMapping = getArtifactNameToConstantMapping().map {
@@ -68,11 +69,17 @@ class BundledDependenciesTest {
         receivedKeys.writeText(receivedMapping.joinToString(separator = "\n", postfix = "\n"))
 
         val breakingChanges = existingMapping - receivedMapping
-        withClue("diff -u ${existingKeys.absolutePath}  ${receivedKeys.absolutePath}") {
-            breakingChanges should haveSize(0)
-        }
-        withClue("Changes to $existingKeys must be committed, but I got new entries") {
-            if (isInCi()) (receivedMapping - existingMapping) should haveSize(0)
+        if (isInCi()) {
+            withClue("diff -u ${existingKeys.absolutePath}  ${receivedKeys.absolutePath}") {
+                breakingChanges should haveSize(0)
+            }
+            withClue("Changes to $existingKeys must be committed, but I got new entries") {
+                (receivedMapping - existingMapping) should haveSize(0)
+            }
+        } else if (breakingChanges.isNotEmpty()) {
+            removedKeys.appendText(
+                text = breakingChanges.joinToString(separator = "\n", postfix = "\n")
+            )
         }
         receivedKeys.copyTo(existingKeys, overwrite = true)
         receivedKeys.deleteOnExit()


### PR DESCRIPTION
This ensures that going forward, updating refreshVersions will not
cause unexpected dependency upgrades.

Thanks @brady-aiello for pairing on that one!

## 🧪 How Has This Been Tested?

I tested adding, and removing in the `sample-groovy`, but didn't keep the changes in git because it's a one-time operation.