### PR TITLE
Use settings.gradle.kts value in bootstrap and of core and setup

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -44,7 +44,8 @@ import java.io.File
 @JvmName("bootstrap")
 fun Settings.bootstrapRefreshVersionsCore(
     artifactVersionKeyRules: List<String> = emptyList(),
-    versionsPropertiesFile: File = rootDir.resolve("versions.properties"),
+    versionsPropertiesFile: File = extension.versionsPropertiesFile
+        ?: settings.rootDir.resolve("versions.properties"),
     getRemovedDependenciesVersionsKeys: () -> Map<ModuleId.Maven, String> = { emptyMap() }
 ) {
     require(settings.isBuildSrc.not()) {

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsSetup.kt
@@ -40,7 +40,8 @@ import java.io.File
 @JvmName("bootstrap")
 fun Settings.bootstrapRefreshVersions(
     extraArtifactVersionKeyRules: List<String> = emptyList(),
-    versionsPropertiesFile: File = rootDir.resolve("versions.properties")
+    versionsPropertiesFile: File = extension.versionsPropertiesFile
+        ?: settings.rootDir.resolve("versions.properties")
 ) {
     require(settings.isBuildSrc.not()) {
         "This bootstrap is only for the root project. For buildSrc, please call " +


### PR DESCRIPTION
## 🚀 Description
Applies use of
`extension.versionsPropertiesFile
                    ?: settings.rootDir.resolve("versions.properties"),
`
in core bootstrap and setup bootstrap as is in plugin bootstrap.

## 📄 Motivation and Context
Fixes #440
I couldn't explain it well enough so this is what I did.

## 🧪 How Has This Been Tested?
built and ran -> now uses the correct file.  not sure how else to test.  it uses the same method of locating the config file in the 'broken' places as is used in the 'working'  place.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [ ] I have read the [guidelines for the development process](https://jmfayard.github.io/refreshVersions/contributing/submitting-prs/dev-process/)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
