### PR TITLE
Error tolerance

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/DependencyVersionsFetcher.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/DependencyVersionsFetcher.kt
@@ -1,37 +1,69 @@
 package de.fayard.refreshVersions.core
 
+import okio.IOException
 import org.gradle.api.Incubating
-import java.io.IOException
 
 @Incubating
 abstract class DependencyVersionsFetcher protected constructor(
     val moduleId: ModuleId,
-    val repoKey: Any
+    val repoUrlOrKey: String
 ) {
 
     companion object;
 
-    @Throws(IOException::class, Exception::class)
-    abstract suspend fun getAvailableVersionsOrNull(versionFilter: ((Version) -> Boolean)?): SuccessfulResult?
+    abstract suspend fun attemptGettingAvailableVersions(versionFilter: ((Version) -> Boolean)?): Result
 
-    data class SuccessfulResult(
-        val lastUpdateTimestampMillis: Long,
-        val availableVersions: List<Version>
+    protected fun failure(cause: FailureCause): Result.Failure = Result.Failure(
+        repoUrlOrKey = repoUrlOrKey,
+        cause = cause
     )
+
+    sealed class Result {
+        object NotFound : Result()
+        data class Success(
+            val lastUpdateTimestampMillis: Long,
+            val availableVersions: List<Version>
+        ) : Result()
+
+        data class Failure(
+            val repoUrlOrKey: String,
+            val cause: FailureCause
+        ) : Result()
+    }
+
+    sealed class FailureCause {
+
+        open val exception: Throwable? = null
+
+        sealed class CommunicationIssue : FailureCause() {
+            data class HttpResponse(
+                val statusCode: Int,
+                override val exception: Throwable? = null
+            ) : CommunicationIssue()
+
+            data class NetworkIssue(
+                override val exception: IOException
+            ) : CommunicationIssue()
+        }
+
+        data class ParsingIssue(
+            override val exception: Throwable
+        ) : FailureCause()
+    }
 
     final override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is DependencyVersionsFetcher) return false
 
         if (moduleId != other.moduleId) return false
-        if (repoKey != other.repoKey) return false
+        if (repoUrlOrKey != other.repoUrlOrKey) return false
 
         return true
     }
 
     final override fun hashCode(): Int {
         var result = moduleId.hashCode()
-        result = 31 * result + repoKey.hashCode()
+        result = 31 * result + repoUrlOrKey.hashCode()
         return result
     }
 }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/DependencyVersionsFetcher.Companion.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/DependencyVersionsFetcher.Companion.kt
@@ -15,7 +15,7 @@ internal fun DependencyVersionsFetcher.Companion.forMaven(
     dependency: Dependency,
     repository: MavenArtifactRepository // TODO: Support Ivy repositories
 ): DependencyVersionsFetcher? {
-    val group = dependency.group ?: return null // TODO: Support NPM dependencies from Kotlin/JS
+    val group = dependency.group ?: return null
     val name = dependency.name
     return when (repository.url.scheme) {
         "https", "http" -> MavenDependencyVersionsFetcherHttp(

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/DependencyWithVersionCandidates.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/DependencyWithVersionCandidates.kt
@@ -1,10 +1,12 @@
 package de.fayard.refreshVersions.core.internal
 
+import de.fayard.refreshVersions.core.DependencyVersionsFetcher
 import de.fayard.refreshVersions.core.ModuleId
 import de.fayard.refreshVersions.core.Version
 
 internal data class DependencyWithVersionCandidates(
     val moduleId: ModuleId,
     val currentVersion: String,
-    val versionsCandidates: List<Version>
+    val versionsCandidates: List<Version>,
+    val failures: List<DependencyVersionsFetcher.Result.Failure>
 )

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/GettingVersionCandidates.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/GettingVersionCandidates.kt
@@ -12,7 +12,6 @@ internal suspend fun List<DependencyVersionsFetcher>.getVersionCandidates(
     currentVersion: Version,
     resultMode: VersionCandidatesResultMode
 ): Pair<List<Version>, List<DependencyVersionsFetcher.Result.Failure>> {
-    //TODO: Change return type to also carry the list of failures, and info regarding their origin.
 
     val results = getVersionCandidates(versionFilter = { it > currentVersion })
     val versionsList = results.filterIsInstance<DependencyVersionsFetcher.Result.Success>()

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/MavenDependencyVersionsFetcherFile.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/MavenDependencyVersionsFetcherFile.kt
@@ -1,6 +1,7 @@
 package de.fayard.refreshVersions.core.internal
 
 import de.fayard.refreshVersions.core.ModuleId
+import de.fayard.refreshVersions.core.internal.xor.Xor
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -17,11 +18,11 @@ internal class MavenDependencyVersionsFetcherFile(
         require(repoUrl.endsWith('/'))
     }
 
-    override suspend fun getXmlMetadataOrNull(): String? {
+    override suspend fun attemptGettingXmlMetadata(): Xor<String?, FailureCause.CommunicationIssue> {
         return try {
             val targetDir = repoDir.resolve("${moduleId.group!!.replace('.', '/')}/${moduleId.name}")
-            val fileNames: Array<String> = targetDir.list() ?: return null
-            fileNames.filter {
+            val fileNames: Array<String> = targetDir.list() ?: return Xor.First(null)
+            val xml = fileNames.filter {
                 it.startsWith("maven-metadata") && it.endsWith(".xml")
             }.also {
                 check(it.size <= 1) {
@@ -30,8 +31,9 @@ internal class MavenDependencyVersionsFetcherFile(
             }.singleOrNull()?.let { filename ->
                 targetDir.resolve(filename).readText()
             }
+            Xor.First(xml)
         } catch (e: FileNotFoundException) {
-            null
+            Xor.First(null)
         }
     }
 }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/NewRefreshVersionsImpl.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/NewRefreshVersionsImpl.kt
@@ -72,16 +72,18 @@ internal suspend fun lookupVersionCandidates(
             )
             val selection = DependencySelection(moduleId, Version(resolvedVersion), propertyName)
             async {
+                val (versions, failures) = versionFetchers.getVersionCandidates(
+                    currentVersion = Version(resolvedVersion),
+                    resultMode = resultMode
+                )
                 DependencyWithVersionCandidates(
                     moduleId = moduleId,
                     currentVersion = resolvedVersion,
-                    versionsCandidates = versionFetchers.getVersionCandidates(
-                        currentVersion = Version(resolvedVersion),
-                        resultMode = resultMode
-                    ).filterNot { version ->
+                    versionsCandidates = versions.filterNot { version ->
                         selection.candidate = version
                         versionRejectionFilter(selection)
-                    }
+                    },
+                    failures = failures
                 )
             }
         }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/NewRefreshVersionsImpl.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/NewRefreshVersionsImpl.kt
@@ -66,19 +66,17 @@ internal suspend fun lookupVersionCandidates(
             val resolvedVersion = resolveVersion(
                 properties = versionMap,
                 key = propertyName
-            ) ?: `Write versions candidates using latest most stable version and get it`(
-                propertyName = propertyName,
-                dependencyVersionsFetchers = versionFetchers
-            )
-            val selection = DependencySelection(moduleId, Version(resolvedVersion), propertyName)
+            )?.let { Version(it) }
             async {
                 val (versions, failures) = versionFetchers.getVersionCandidates(
-                    currentVersion = Version(resolvedVersion),
+                    currentVersion = resolvedVersion ?: Version(""),
                     resultMode = resultMode
                 )
+                val currentVersion = resolvedVersion ?: versions.latestMostStable()
+                val selection = DependencySelection(moduleId, currentVersion, propertyName)
                 DependencyWithVersionCandidates(
                     moduleId = moduleId,
-                    currentVersion = resolvedVersion,
+                    currentVersion = currentVersion.value,
                     versionsCandidates = versions.filterNot { version ->
                         selection.candidate = version
                         versionRejectionFilter(selection)

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/PluginWithVersionCandidates.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/PluginWithVersionCandidates.kt
@@ -1,9 +1,11 @@
 package de.fayard.refreshVersions.core.internal
 
+import de.fayard.refreshVersions.core.DependencyVersionsFetcher
 import de.fayard.refreshVersions.core.Version
 
 internal data class PluginWithVersionCandidates(
     val pluginId: String,
     val currentVersion: String,
-    val versionsCandidates: List<Version>
+    val versionsCandidates: List<Version>,
+    val failures: List<DependencyVersionsFetcher.Result.Failure>
 )

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/SettingsPluginsUpdatesFinder.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/SettingsPluginsUpdatesFinder.kt
@@ -67,13 +67,15 @@ internal object SettingsPluginsUpdatesFinder {
             }.mapNotNull { (moduleId: ModuleId, currentVersion, versionsFetchers) ->
                 val pluginId = moduleId.group ?: return@mapNotNull null
                 async {
+                    val (versions, failures) = versionsFetchers.getVersionCandidates(
+                        currentVersion = Version(currentVersion),
+                        resultMode = mode
+                    )
                     PluginWithVersionCandidates(
                         pluginId = pluginId,
                         currentVersion = currentVersion,
-                        versionsCandidates = versionsFetchers.getVersionCandidates(
-                            currentVersion = Version(currentVersion),
-                            resultMode = mode
-                        )
+                        versionsCandidates = versions,
+                        failures = failures
                     )
                 }
             }.awaitAll().let { pluginsWithVersionCandidates ->

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPlaceholdersReplacement.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPlaceholdersReplacement.kt
@@ -302,7 +302,7 @@ private fun `Write versions candidates using latest most stable version and get 
             resultMode = RefreshVersionsConfigHolder.resultMode
         ).let { (versionCandidates, failures) ->
             if (versionCandidates.isEmpty()) {
-                TODO("Handle no versions found with a precise and helfpul error message")
+                TODO("Handle no versions found with a precise and helpful error message")
                 //TODO: Mention to moduleId or dependency in a readable way
                 // Specify the failures count
                 // List all the failures, along with stacktrace from the exception/throwable, if any.

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPlaceholdersReplacement.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPlaceholdersReplacement.kt
@@ -310,8 +310,7 @@ private fun `Write versions candidates using latest most stable version and get 
                 )
                 throw GradleException(errorMessage)
             }
-            val bestStability = versionCandidates.minByOrNull { it.stabilityLevel }!!.stabilityLevel
-            val versionToUse = versionCandidates.last { it.stabilityLevel == bestStability }
+            val versionToUse = versionCandidates.latestMostStable()
             VersionsPropertiesModel.writeWithNewEntry(
                 propertyName = propertyName,
                 versionsCandidates = versionCandidates.dropWhile { it != versionToUse },
@@ -320,6 +319,12 @@ private fun `Write versions candidates using latest most stable version and get 
             versionToUse.value
         }
     }
+}
+
+internal fun List<Version>.latestMostStable(): Version {
+    val bestStability = minByOrNull { it.stabilityLevel }?.stabilityLevel
+        ?: throw NoSuchElementException("Can't get latest most stable version in an empty list")
+    return last { it.stabilityLevel == bestStability }
 }
 
 private fun noVersionsFoundErrorMessage(

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPlaceholdersReplacement.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsPlaceholdersReplacement.kt
@@ -306,6 +306,7 @@ private fun `Write versions candidates using latest most stable version and get 
             if (versionCandidates.isEmpty()) {
                 val errorMessage = noVersionsFoundErrorMessage(
                     moduleId = moduleId,
+                    fetchers = dependencyVersionsFetchers,
                     failures = failures
                 )
                 throw GradleException(errorMessage)
@@ -329,14 +330,19 @@ internal fun List<Version>.latestMostStable(): Version {
 
 private fun noVersionsFoundErrorMessage(
     moduleId: ModuleId,
+    fetchers: List<DependencyVersionsFetcher>,
     failures: List<DependencyVersionsFetcher.Result.Failure>
 ): String = buildString {
-    append("Unable to find ")
+    append("Unable to find the ")
     append(moduleId.notation())
+    append(" dependency ")
     when (failures.size) {
-        0 -> append(" because no repository was found.")
-        1 -> appendLine(" in the following repository:")
-        else -> appendLine(" in the following repositories:")
+        0 ->  when (fetchers.size) {
+            0 -> append("because no repository was found.")
+            else -> append("because none of the configured repositories contain it.")
+        }
+        1 -> appendLine("because of a failure in the following repository:")
+        else -> appendLine("because of a failure in the following repositories:")
     }
     failures.forEach { failure ->
         append(failure.repoUrlOrKey)

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/failures/FailureCause.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/failures/FailureCause.kt
@@ -1,0 +1,18 @@
+package de.fayard.refreshVersions.core.internal.failures
+
+import de.fayard.refreshVersions.core.DependencyVersionsFetcher
+
+internal fun DependencyVersionsFetcher.FailureCause.oneLineSummary(): String = when (this) {
+    is DependencyVersionsFetcher.FailureCause.CommunicationIssue.HttpResponse -> {
+        val message = exception?.message ?: ""
+        "http status code $statusCode $message"
+    }
+    is DependencyVersionsFetcher.FailureCause.CommunicationIssue.NetworkIssue -> {
+        val message = exception.message ?: exception.cause?.message ?: ""
+        "network or server issue (${exception.javaClass} ${message})"
+    }
+    is DependencyVersionsFetcher.FailureCause.ParsingIssue -> {
+        val message = exception.message ?: exception.cause?.message ?: ""
+        "error while parsing metadata (${exception.javaClass} ${message})"
+    }
+}

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/legacy/LegacyBoostrapUpdatesFinder.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/legacy/LegacyBoostrapUpdatesFinder.kt
@@ -27,13 +27,15 @@ internal object LegacyBoostrapUpdatesFinder {
 
         val currentVersion = RefreshVersionsCorePlugin.currentVersion
 
+        val (versions, failures) = versionsFetchers.getVersionCandidates(
+            currentVersion = Version(currentVersion),
+            resultMode = resultMode
+        )
         return DependencyWithVersionCandidates(
             moduleId = moduleId,
             currentVersion = currentVersion,
-            versionsCandidates = versionsFetchers.getVersionCandidates(
-                currentVersion = Version(currentVersion),
-                resultMode = resultMode
-            )
+            versionsCandidates = versions,
+            failures = failures
         )
     }
 }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/npm/NpmDependencyVersionsFetcherHttp.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/npm/NpmDependencyVersionsFetcherHttp.kt
@@ -39,7 +39,6 @@ internal class NpmDependencyVersionsFetcherHttp(
         url(metadataUrlForArtifact)
     }.build()
 
-
     override suspend fun attemptGettingAvailableVersions(versionFilter: ((Version) -> Boolean)?): Result {
 
         val metadata: NpmMetadata = when (val result = attemptGettingNpmMetadata()) {

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/npm/NpmDependencyVersionsFetcherHttp.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/npm/NpmDependencyVersionsFetcherHttp.kt
@@ -1,15 +1,19 @@
 package de.fayard.refreshVersions.core.internal.npm
 
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import de.fayard.refreshVersions.core.DependencyVersionsFetcher
 import de.fayard.refreshVersions.core.ModuleId
 import de.fayard.refreshVersions.core.Version
 import de.fayard.refreshVersions.core.extensions.okhttp.await
+import de.fayard.refreshVersions.core.internal.xor.Xor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import retrofit2.HttpException
 import retrofit2.Response
+import java.io.IOException
 import java.time.Instant
 
 internal class NpmDependencyVersionsFetcherHttp(
@@ -18,7 +22,7 @@ internal class NpmDependencyVersionsFetcherHttp(
     val repoUrl: String = "https://registry.npmjs.org/"
 ) : DependencyVersionsFetcher(
     moduleId = moduleId,
-    repoKey = repoUrl
+    repoUrlOrKey = repoUrl
 ) {
     init {
         require(repoUrl.endsWith('/'))
@@ -36,12 +40,17 @@ internal class NpmDependencyVersionsFetcherHttp(
     }.build()
 
 
-    override suspend fun getAvailableVersionsOrNull(versionFilter: ((Version) -> Boolean)?): SuccessfulResult? {
+    override suspend fun attemptGettingAvailableVersions(versionFilter: ((Version) -> Boolean)?): Result {
 
-        val metadata = getNpmMetadataOrNull() ?: return null
+        val metadata: NpmMetadata = when (val result = attemptGettingNpmMetadata()) {
+            is Xor.First -> result.value ?: return Result.NotFound
+            is Xor.Second -> return failure(result.value)
+        }
 
-        val allVersions = parseVersionsFromNpmMetaData(metadata)
-        return SuccessfulResult(
+        val allVersions = runCatching {
+            parseVersionsFromNpmMetaData(metadata)
+        }.getOrElse { return failure(FailureCause.ParsingIssue(it)) }
+        return Result.Success(
             lastUpdateTimestampMillis = parseLastUpdatedFromNpmMetaData(metadata),
             availableVersions = if (versionFilter == null) {
                 allVersions
@@ -51,19 +60,32 @@ internal class NpmDependencyVersionsFetcherHttp(
         )
     }
 
-    private suspend fun getNpmMetadataOrNull(): NpmMetadata? {
-        return httpClient.newCall(request).await().use { response ->
+    private suspend fun attemptGettingNpmMetadata(): Xor<NpmMetadata?, FailureCause> = runCatching {
+        httpClient.newCall(request).await().use { response ->
             if (response.isSuccessful) {
-                response.use {
+                val result = response.use {
                     val jsonAdapter = moshi.adapter(NpmMetadata::class.java)
                     jsonAdapter.fromJson(it.body!!.source())
                 }
+                Xor.First(result)
             } else when (response.code) {
-                404 -> null // Normal not found result
-                401 -> null // Returned by some repositories that have optional authentication
-                else -> throw HttpException(Response.error<Any?>(response.code, response.body!!))
+                404 -> Xor.First(null) // Normal not found result
+                401 -> Xor.First(null) // Returned by some repositories that have optional authentication
+                else -> {
+                    val failure = FailureCause.CommunicationIssue.HttpResponse(
+                        statusCode = response.code,
+                        exception = HttpException(Response.error<Any?>(response.code, response.body!!))
+                    )
+                    Xor.Second(failure)
+                }
             }
         }
+    }.getOrElse {
+        val failure = when (it) {
+            is JsonEncodingException, is JsonDataException -> FailureCause.ParsingIssue(it)
+            else -> FailureCause.CommunicationIssue.NetworkIssue(it as? IOException ?: IOException(it))
+        }
+        Xor.Second(failure)
     }
 
     companion object {

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
@@ -80,7 +80,6 @@ internal actual data class VersionsPropertiesModel(
             append(failure.cause.oneLineSummary())
         }
 
-
         val versionKeysPrefixes = listOf("plugin", "version")
 
         fun versionsPropertiesHeader(

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
@@ -1,6 +1,7 @@
 package de.fayard.refreshVersions.core.internal.versions
 
 import de.fayard.refreshVersions.core.DependencyVersionsFetcher
+import de.fayard.refreshVersions.core.internal.failures.oneLineSummary
 
 /**
  * @property dependencyNotationRemovalsRevision Designed to be used only for snapshot publications.
@@ -76,18 +77,7 @@ internal actual data class VersionsPropertiesModel(
             append(failureComment)
             append(failure.repoUrlOrKey)
             append(" Cause: ")
-            val detail = when (val cause = failure.cause) {
-                is DependencyVersionsFetcher.FailureCause.CommunicationIssue.HttpResponse -> {
-                    "http status code ${cause.statusCode}"
-                }
-                is DependencyVersionsFetcher.FailureCause.CommunicationIssue.NetworkIssue -> {
-                    "network or server issue(${cause.exception})"
-                }
-                is DependencyVersionsFetcher.FailureCause.ParsingIssue -> {
-                    "error while parsing metadata (${cause.exception})"
-                }
-            }
-            append(detail)
+            append(failure.cause.oneLineSummary())
         }
 
 

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/versions/VersionsPropertiesModel.kt
@@ -1,5 +1,7 @@
 package de.fayard.refreshVersions.core.internal.versions
 
+import de.fayard.refreshVersions.core.DependencyVersionsFetcher
+
 /**
  * @property dependencyNotationRemovalsRevision Designed to be used only for snapshot publications.
  */
@@ -67,6 +69,27 @@ internal actual data class VersionsPropertiesModel(
         const val availableComment = "# available"
 
         const val unusedEntryComment = "## unused"
+
+        const val failureComment = "## failed to check repo "
+
+        fun failureComment(failure: DependencyVersionsFetcher.Result.Failure): String = buildString {
+            append(failureComment)
+            append(failure.repoUrlOrKey)
+            append(" Cause: ")
+            val detail = when (val cause = failure.cause) {
+                is DependencyVersionsFetcher.FailureCause.CommunicationIssue.HttpResponse -> {
+                    "http status code ${cause.statusCode}"
+                }
+                is DependencyVersionsFetcher.FailureCause.CommunicationIssue.NetworkIssue -> {
+                    "network or server issue(${cause.exception})"
+                }
+                is DependencyVersionsFetcher.FailureCause.ParsingIssue -> {
+                    "error while parsing metadata (${cause.exception})"
+                }
+            }
+            append(detail)
+        }
+
 
         val versionKeysPrefixes = listOf("plugin", "version")
 

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/xor/Xor.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/xor/Xor.kt
@@ -1,0 +1,16 @@
+package de.fayard.refreshVersions.core.internal.xor
+
+/**
+ * A class similar to `Either` from Arrow, but with less features (because some are not needed).
+ *
+ * XOR stands for eXclusive OR.
+ */
+internal sealed class Xor<out FirstT, out SecondT> {
+
+    fun firstOrNull(): FirstT? = if (this is First) this.value else null
+    fun secondOrNull(): SecondT? = if (this is Second) this.value else null
+
+    data class First<LeftT>(val value: LeftT) : Xor<LeftT, Nothing>()
+
+    data class Second<RightT>(val value: RightT) : Xor<Nothing, RightT>()
+}

--- a/plugins/core/src/test/kotlin/de/fayard/refreshVersions/core/SettingsPluginUpdaterTest.kt
+++ b/plugins/core/src/test/kotlin/de/fayard/refreshVersions/core/SettingsPluginUpdaterTest.kt
@@ -76,7 +76,8 @@ class SettingsPluginUpdaterTest {
                 PluginWithVersionCandidates(
                     pluginId = pluginId,
                     currentVersion = currentVersion,
-                    versionsCandidates = pluginsVersions[pluginId]!!.subListAfter(currentVersion).map { Version(it) }
+                    versionsCandidates = pluginsVersions[pluginId]!!.subListAfter(currentVersion).map { Version(it) },
+                    failures = emptyList()
                 )
             }
         )

--- a/plugins/core/src/test/resources/removals-replacement/sample-kotlin-untouched/kt-input.build.gradle.kts
+++ b/plugins/core/src/test/resources/removals-replacement/sample-kotlin-untouched/kt-input.build.gradle.kts
@@ -63,7 +63,7 @@ getKotlinPluginVersion().let {
 }
 
 tasks.register("run", JavaExec::class.java) {
-    this.main = "de.fayard.GuavaTest"
+    mainClass.set("de.fayard.GuavaTest")
 }
 
 tasks.withType<KotlinCompile> {

--- a/plugins/core/src/testFixtures/kotlin/testutils/GetVersionCandidates.kt
+++ b/plugins/core/src/testFixtures/kotlin/testutils/GetVersionCandidates.kt
@@ -27,4 +27,7 @@ suspend fun getVersionCandidates(
         filterMode = VersionCandidatesResultMode.FilterMode.LatestByStabilityLevel,
         sortingMode = VersionCandidatesResultMode.SortingMode.ByVersion
     )
-)
+).let { (versions, failures) ->
+    check(failures.isEmpty())
+    versions
+}

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -60,7 +60,7 @@ getKotlinPluginVersion().let {
 }
 
 tasks.register<JavaExec>("run") {
-    this.main = "de.fayard.GuavaTest"
+    mainClass.set("de.fayard.GuavaTest")
 }
 
 tasks.withType<KotlinCompile>().configureEach {


### PR DESCRIPTION
## 🚀 Description

These changes avoid refreshVersions crashing if there's one failure for one of the repos or dependencies, or related to the network stability. Instead, error messages will be inserted contextually in the `versions.properties` file.

## 📄 Motivation and Context

This PR resolves #468

## 🧪 How Has This Been Tested?

Tested locally with purposefully wrong repository urls.
Worked well for timeout, and for non existing domain:
- failure comments are added at the right place in `versions.properties` if an error happens.
- failure comments are updated if the errors change.
- failure comments are removed after running `refreshVersions` if there's no errors in the subsequent run.

In the case of non-repo existing domains, they return 404 errors, and we can't differenciated them from what an actual repo missing the requested artifact would return, so they are ignored in both cases.
