### PR TITLE
Change AGP to dependency notation

### DIFF
--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath("com.android.tools.build:gradle:_")
+    classpath(Android.tools.build.gradlePlugin)
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:_")
   }
 }


### PR DESCRIPTION
Hello,

I spotted that the Android Sample App uses the underscore notation instead of dependency notation for the AGP.

This changes the build.gradle.kts to use dependency notation instead.

## Why?

Updating of example

## How?

Edited build.gradle.kts to use dependency notation for AGP

## Testing?

Built project with no errors/warnings after change.
