### PR TITLE
Feature/ Add navigation library for Koin group

### DIFF
--- a/plugins/dependencies/src/main/kotlin/dependencies/Koin.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/Koin.kt
@@ -24,6 +24,7 @@ object Koin : DependencyGroup(
     val android = module("koin-android")
     val androidCompat = module("koin-android-compat")
     val workManager = module("koin-androidx-workmanager")
+    val navigation = module("koin-androidx-navigation")
     val compose = module("koin-androidx-compose")
     val ktor = module("koin-ktor")
     val slf4j = module("koin-logger-slf4j")


### PR DESCRIPTION
Hello,

Add new library in the Koin group : `io.insert-koin:koin-androidx-navigation:$koin_version`

First version is 3.1.3 (https://search.maven.org/artifact/io.insert-koin/koin-androidx-navigation)

Official Koin libraries list : https://insert-koin.io/docs/setup/v3.1