### PR TITLE
Fix `StabilityLevel` detection for jgit

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/Version.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/Version.kt
@@ -105,6 +105,7 @@ data class Version(val value: String) : Comparable<Version> {
 
         private val knownVersionSuffixes = listOf("-android", "-jre")
         private val knownStableKeywords = listOf("RELEASE", "FINAL", "GA")
+        private val knownStableSuffixes = listOf("-r")
         private val digitsOnlyBasedVersionNumberRegex = "^[\\d,.v-]+$".toRegex()
 
         private fun Version.isStable(): Boolean {
@@ -168,6 +169,9 @@ data class Version(val value: String) : Comparable<Version> {
         private fun String.withoutKnownSuffixes(): String {
             var result: String = this
             for (suffix in knownVersionSuffixes) {
+                result = result.removeSuffix(suffix)
+            }
+            for (suffix in knownStableSuffixes) {
                 result = result.removeSuffix(suffix)
             }
             return result

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/Version.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/Version.kt
@@ -116,7 +116,7 @@ data class Version(val value: String) : Comparable<Version> {
 
         private fun Version.isMilestone(): Boolean {
             val version = value
-            return when (val indexOfM = version.indexOfLast { it == 'M' }) {
+            return when (val indexOfM = version.indexOfLast { it.toUpperCase() == 'M' }) {
                 -1 -> false
                 version.lastIndex -> false
                 else -> version.substring(startIndex = indexOfM + 1).all { it.isDigit() }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/Version.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/Version.kt
@@ -105,7 +105,7 @@ data class Version(val value: String) : Comparable<Version> {
 
         private val knownVersionSuffixes = listOf("-android", "-jre")
         private val knownStableKeywords = listOf("RELEASE", "FINAL", "GA")
-        private val digitsOnlyBasedVersionNumberRegex = "^[0-9,.v-]+$".toRegex()
+        private val digitsOnlyBasedVersionNumberRegex = "^[\\d,.v-]+$".toRegex()
 
         private fun Version.isStable(): Boolean {
             val version = value


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->
<!-- Be sure to read the guidelines for the development process => https://jmfayard.github.io/refreshVersions/contributing/submitting-prs/dev-process -->

Hello/bonjour,

## What?

Resolves #551.

This change primarily involves changes to fix the stability detection of [jgit](https://www.eclipse.org/jgit/).

This PR contains the following changes:
- [x] Add `knownStableSuffixes`, which are stripped in `String.withoutKnownSuffixes()`. (Currently `listOf("-r")`)
- [x] Make detection of milestone versions case-insensitive
- [x] Use `[\d]` instead of `[0-9]` in regex

## Why?

Reasons for each change:

- The variable `knownStableSuffixes` was created (currently set to `listOf("-r")`) so that the version `6.1.0.202203080745-r` is properly resolved as `Stable`.
- Case-insensitive milestone detection was added so that the version `5.0.0.201805151920-m7` is properly resolved as `Milestone`.
- `[\d]` was used in the regex instead of `[0-9]` to simplify it.

## How?

Changes are self-explanatory.

## Testing?

There currently exists no tests for `Version#stabilityLevel`.

However, if you wish to manually test against a sample set of jgit verions, you may find them on [maven central](https://search.maven.org/artifact/org.eclipse.jgit/org.eclipse.jgit).
