### PR TITLE
Disable two tasks by default with FeatureFlag OLD_TASKS

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/FeatureFlag.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/FeatureFlag.kt
@@ -36,6 +36,7 @@ enum class FeatureFlag(private val enabledByDefault: Boolean?) {
     // Instead, mark it as deprecated, like this: @Deprecated("your message here")
 
     GRADLE_UPDATES(enabledByDefault = true),
+    OLD_TASKS(enabledByDefault = false),
     LIBS(enabledByDefault = false),
     NPM_IMPLICIT_RANGE(enabledByDefault = false),
     VERSIONS_CATALOG(enabledByDefault = true),
@@ -54,13 +55,13 @@ enum class FeatureFlag(private val enabledByDefault: Boolean?) {
      * Intended usage:
      * `if (GRADLE_UPDATES.isEnabled) lookupAvailableGradleVersions() else emptyList()`
      */
-    internal val isEnabled: Boolean
+    @InternalRefreshVersionsApi val isEnabled: Boolean
         get() = when (enabledByDefault) {
             false -> userSettings[this] == true
             true -> userSettings[this] != false
             null -> false
         }
 
-    internal val isNotEnabled
+    @InternalRefreshVersionsApi val isNotEnabled
         get() = isEnabled.not()
 }

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsDependenciesMappingTask.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsDependenciesMappingTask.kt
@@ -5,7 +5,7 @@ import de.fayard.refreshVersions.internal.getArtifactNameToConstantMapping
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-class RefreshVersionsDependenciesMappingTask: DefaultTask() {
+open class RefreshVersionsDependenciesMappingTask: DefaultTask() {
 
     @InternalRefreshVersionsApi
     companion object {

--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsPlugin.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsPlugin.kt
@@ -165,22 +165,6 @@ open class RefreshVersionsPlugin : Plugin<Any> {
     private fun registerDependenciesTask(project: Project) {
         if (project != project.rootProject) return // We want the tasks only for the root project
 
-        project.tasks.register<RefreshVersionsDependenciesMigrationTask>(
-            RefreshVersionsDependenciesMigrationTask.TASK_NAME
-        ) {
-            description = RefreshVersionsDependenciesMigrationTask.DESCRIPTION
-            group = RefreshVersionsCorePlugin.GROUP
-            finalizedBy(RefreshVersionsTask.TASK_NAME)
-            skipConfigurationCache()
-        }
-
-        project.tasks.register<RefreshVersionsDependenciesMappingTask>(
-            name = RefreshVersionsDependenciesMappingTask.TASK_NAME
-        ) {
-            description = RefreshVersionsDependenciesMappingTask.DESCRIPTION
-            group = RefreshVersionsCorePlugin.GROUP
-        }
-
         project.tasks.register<RefreshVersionsCatalogTask>(
             name = RefreshVersionsCatalogTask.TASK_NAME
         ) {
@@ -196,6 +180,24 @@ open class RefreshVersionsPlugin : Plugin<Any> {
             description = RefreshVersionsMigrateTask.DESCRIPTION
             group = RefreshVersionsCorePlugin.GROUP
             skipConfigurationCache()
+        }
+
+        if (FeatureFlag.OLD_TASKS.isEnabled) {
+            project.tasks.register<RefreshVersionsDependenciesMigrationTask>(
+                RefreshVersionsDependenciesMigrationTask.TASK_NAME
+            ) {
+                description = RefreshVersionsDependenciesMigrationTask.DESCRIPTION
+                group = RefreshVersionsCorePlugin.GROUP
+                finalizedBy(RefreshVersionsTask.TASK_NAME)
+                skipConfigurationCache()
+            }
+
+            project.tasks.register<RefreshVersionsDependenciesMappingTask>(
+                name = RefreshVersionsDependenciesMappingTask.TASK_NAME
+            ) {
+                description = RefreshVersionsDependenciesMappingTask.DESCRIPTION
+                group = RefreshVersionsCorePlugin.GROUP
+            }
         }
     }
 

--- a/sample-kotlin/settings.gradle.kts
+++ b/sample-kotlin/settings.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 refreshVersions {
     featureFlags {
+        enable(OLD_TASKS)
         enable(LIBS)
         disable(GRADLE_UPDATES)
         disable(VERSIONS_CATALOG)


### PR DESCRIPTION
We have two mostly obsolete tasks

- `refreshVersionsDependenciesMapping` was never really useful (I never used it) and is now fully replaced by the web page https://jmfayard.github.io/refreshVersions/dependencies-notations/
- `migrateToRefreshVersionsDependenciesConstants` who was the precursor to `refreshVersionsMigrate`

Without them the tasks look cleaner:

<img width="503" alt="Notification_Center" src="https://user-images.githubusercontent.com/459464/188469102-7b4cd56a-8326-4c0c-951f-fdec33717105.png">

On the other hand we never know, someone might use those tasks.

So instead of removing them, I put them behind a feature flag disabled by default