### PR TITLE
Draft article moved to refreshVersions wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ If you want to use only `versions.properties` and the [built-in dependencies not
 
 `./gradlew refreshVersionsMigrate --mode=VersionsPropertiesOnly`
 
-If you want to [also use Gradle's Versions Catalogs](https://github.com/jmfayard/refreshVersions/wiki/RefreshVersions-%E2%99%A5%EF%B8%8F-Gradle-Version-Catalog), run:
+Gradle's Versions Catalogs support was added in 0.50.0. Migrate to it with:
 
 `./gradlew refreshVersionsMigrate --mode=VersionCatalogAndVersionProperties`
+
+[See dicussion thread here](https://github.com/jmfayard/refreshVersions/discussions/592)
 
 **Find available updates in `versions.properties`:**
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you want to use only `versions.properties` and the [built-in dependencies not
 
 `./gradlew refreshVersionsMigrate --mode=VersionsPropertiesOnly`
 
-If you want to [also use Gradle's Versions Catalogs](https://github.com/jmfayard/drafts/wiki/RefreshVersions-%E2%99%A5%EF%B8%8F-Gradle-Version-Catalog), run:
+If you want to [also use Gradle's Versions Catalogs](https://github.com/jmfayard/refreshVersions/wiki/RefreshVersions-%E2%99%A5%EF%B8%8F-Gradle-Version-Catalog), run:
 
 `./gradlew refreshVersionsMigrate --mode=VersionCatalogAndVersionProperties`
 


### PR DESCRIPTION
The draft article about refreshVersions and Versions Catalog belong to refreshVersions's wiki and not my own.

So I moved it to https://github.com/jmfayard/refreshVersions/wiki/RefreshVersions-%E2%99%A5%EF%B8%8F-Gradle-Version-Catalog

I also updated the link at https://github.com/jmfayard/refreshVersions/discussions/592

Any other place i am missing?

Here I am updating the README to point to the discussion for now https://github.com/jmfayard/refreshVersions/discussions/592

PS @LouisCAD  to clone the wiki as git repository, just run 

`git clone https://github.com/jmfayard/refreshVersions.wiki.git`
