### PR TITLE
[Issue-615] Removed `molecule-testing` artifact

### DIFF
--- a/plugins/dependencies/src/main/kotlin/dependencies/CashApp.kt
+++ b/plugins/dependencies/src/main/kotlin/dependencies/CashApp.kt
@@ -61,6 +61,5 @@ object CashApp {
     object Molecule : DependencyGroup(group = "app.cash.molecule") {
         val gradlePlugin = module("molecule-gradle-plugin")
         val runtime = module("molecule-runtime")
-        val test = module("molecule-testing")
     }
 }

--- a/plugins/dependencies/src/main/resources/removals-revisions-history.md
+++ b/plugins/dependencies/src/main/resources/removals-revisions-history.md
@@ -703,3 +703,9 @@ id:[com.google.accompanist:accompanist-swiperefresh]
 
 ~~Google.accompanist.systemuicontroller~~
 id:[com.google.accompanist:accompanist-systemuicontroller]
+
+## Revision 15
+
+~~CashApp.molecule.test~~
+// The testing module was removed in version 0.5.0
+id:[app.cash.molecule:molecule-testing]

--- a/plugins/dependencies/src/main/resources/removed-dependencies-versions-keys.txt
+++ b/plugins/dependencies/src/main/resources/removed-dependencies-versions-keys.txt
@@ -106,3 +106,4 @@ io.ktor..ktor-velocity=version.ktor
 androidx.health..health-connect-client=version.androidx.health-connect-client
 com.google.accompanist..accompanist-glide=version.google.accompanist
 com.google.accompanist..accompanist-imageloading-core=version.google.accompanist
+app.cash.molecule..molecule-testing=version.app.cash.molecule

--- a/plugins/dependencies/src/test/resources/bundled-dependencies-validated.txt
+++ b/plugins/dependencies/src/test/resources/bundled-dependencies-validated.txt
@@ -325,7 +325,6 @@ app.cash.copper:copper-rx3
 app.cash.licensee:licensee-gradle-plugin
 app.cash.molecule:molecule-gradle-plugin
 app.cash.molecule:molecule-runtime
-app.cash.molecule:molecule-testing
 app.cash.turbine:turbine
 co.touchlab:kermit
 co.touchlab:kermit-bugsnag

--- a/plugins/dependencies/src/test/resources/dependencies-mapping-validated.txt
+++ b/plugins/dependencies/src/test/resources/dependencies-mapping-validated.txt
@@ -326,7 +326,6 @@ app.cash.copper..copper-rx3=CashApp.copper.rx3
 app.cash.licensee..licensee-gradle-plugin=CashApp.licenseeGradlePlugin
 app.cash.molecule..molecule-gradle-plugin=CashApp.molecule.gradlePlugin
 app.cash.molecule..molecule-runtime=CashApp.molecule.runtime
-app.cash.molecule..molecule-testing=CashApp.molecule.test
 app.cash.turbine..turbine=CashApp.turbine
 co.touchlab..kermit-bugsnag-test=Touchlab.kermit.bugsnagTest
 co.touchlab..kermit-bugsnag=Touchlab.kermit.bugsnag

--- a/plugins/dependencies/src/test/resources/dependencies-versions-key-validated.txt
+++ b/plugins/dependencies/src/test/resources/dependencies-versions-key-validated.txt
@@ -325,7 +325,6 @@ app.cash.copper..copper-rx3=version.app.cash.copper
 app.cash.licensee..licensee-gradle-plugin=version.app.cash.licensee
 app.cash.molecule..molecule-gradle-plugin=version.app.cash.molecule
 app.cash.molecule..molecule-runtime=version.app.cash.molecule
-app.cash.molecule..molecule-testing=version.app.cash.molecule
 app.cash.turbine..turbine=version.app.cash.turbine
 co.touchlab..kermit-bugsnag-test=version.kermit
 co.touchlab..kermit-bugsnag=version.kermit


### PR DESCRIPTION
Hello/bonjour, this PR updates the dependency notations for [CashApp/Molecule](https://github.com/cashapp/molecule).

## What?

Resolves #615 

Removes a dependency notation for an artifact that has been removed.

## Why?

To stay in line with current artifacts in [CashApp/Molecule](https://github.com/cashapp/molecule)

## How?

Removed the dependency notation.

## Testing?

- Ran ./gradlew check
- Published to maven local, and consumed in a project locally
