### PR TITLE
[Issue-618] Add additional condition for logging of gradle version catalog changes

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCleanupTask.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCleanupTask.kt
@@ -53,7 +53,10 @@ open class RefreshVersionsCleanupTask : DefaultTask() {
 
     @TaskAction
     fun cleanUpVersionsCatalog() {
-        if (VersionsCatalogs.isSupported() && FeatureFlag.VERSIONS_CATALOG.isEnabled) {
+        val settingsFiles = OutputFile.settingsFiles
+            .filter { it.existed }
+
+        if (settingsFiles.contains(OutputFile.GRADLE_VERSIONS_CATALOG) && VersionsCatalogs.isSupported() && FeatureFlag.VERSIONS_CATALOG.isEnabled) {
             val file = File(LIBS_VERSIONS_TOML)
             VersionsCatalogUpdater(file, emptyList()).cleanupComments(file)
             OutputFile.GRADLE_VERSIONS_CATALOG.logFileWasModified()


### PR DESCRIPTION
## What?

Fixes #618 

Add additional condition for logging of gradle version catalog changes

## Why?

When `RefreshVersionsCleanup` task is executed, the log related to the `gradle/lib.version.toml` file that does not exist in the current project is checked.

### Logs
<img width="419" alt="image" src="https://user-images.githubusercontent.com/37795866/191054000-fda7ff98-ece9-4bb2-ad35-64e001ba54e1.png">

### gradle directory
<img width="332" alt="image" src="https://user-images.githubusercontent.com/37795866/191055085-457c8220-d492-4239-bf53-75db8ba3f324.png">


## How?

- So I added additional condition when logging result of `RefreshVersionsCleanup` task.

## Testing?

- None. If there is a convenient way to test it on my side, please recommend.

## Additional info

- If this is intentional or if I misunderstood, please comment.
- I have no information about the code style of this project. So, first of all, I modified it in the simplest way. Any suggestions will be helpful 🙂 